### PR TITLE
chore: scaffold the git-flow governance base

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Trailing whitespace in Markdown is a hard line break — don't strip it.
+[*.md]
+trim_trailing_whitespace = false

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+source_env_if_exists .envrc.local
+
+# Fetch the rotating vended GitHub token (the sanctioned cross-repo/agent
+# credential) and export it as GH_VENDED_TOKEN. Runs only when the
+# infra-aws-local-read Keychain item exists (a provisioned macOS machine),
+# so the repo still works without it. Fetched fresh each shell (the token
+# rotates ~hourly) and never cached; aws-vended-token fails loud on a
+# stale/missing token, so a dead credential surfaces here at shell entry,
+# not as a 401 at first use. Design and grant detail: dotfiles' AGENTS.md
+# Credentials section, infra ADR-0010.
+if command -v security >/dev/null && security find-generic-password -s infra-aws-local-read >/dev/null 2>&1; then
+  if _vt=$(aws-vended-token); then
+    export GH_VENDED_TOKEN="$_vt"
+  else
+    log_error "vended GitHub token unavailable (see the error above)"
+  fi
+  unset _vt
+fi
+
+# Routine GH_TOKEN resolution, in order: a non-empty GH_TOKEN from
+# .envrc.local wins (escape hatch — a freshly minted scoped PAT); else the
+# vended token. The sentinel floor is unconditional and LAST so gh fails
+# closed with a visible 401 instead of silently reaching gh's keyring
+# credential, whichever path left GH_TOKEN empty — the fetch above failed,
+# or the Keychain item was absent and the fetch never ran.
+[[ -z "${GH_TOKEN:-}" && -n "${GH_VENDED_TOKEN:-}" ]] && export GH_TOKEN="$GH_VENDED_TOKEN"
+[[ -z "${GH_TOKEN:-}" ]] && export GH_TOKEN=vended-unavailable-see-84
+
+# git-cliff reads its GitHub API token from GITHUB_TOKEN, not GH_TOKEN —
+# alias it to the same token rather than asking for a second credential.
+# Must come after the resolution above: it inherits the vended token or the
+# sentinel (a loud git-cliff 401 when the vended path is down is intended —
+# use --offline).
+export GITHUB_TOKEN="$GH_TOKEN"

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,0 +1,12 @@
+# shellcheck shell=bash
+# Copy this file to .envrc.local. Routine GitHub auth is the vended token,
+# mapped in .envrc — leave GH_TOKEN empty. Escape hatch: if the vended path
+# is down for long, mint a fresh fine-grained PAT (Contents/Pull
+# requests/Actions read-write, NOT Administration) and fill it here — a
+# non-empty value wins over the vended mapping. Use
+# `env -u GH_TOKEN -u GITHUB_TOKEN gh ...` for anything that needs the
+# full-admin session instead (both vars, since .envrc aliases GITHUB_TOKEN
+# to this same scoped token and gh prefers it) — e.g. the branch-protection
+# bootstrap script. Design and grant detail: dotfiles' AGENTS.md Credentials
+# section, infra ADR-0010.
+export GH_TOKEN=

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,25 @@
+name: Bug report
+description: Something isn't working as expected.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you expected versus what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The minimal steps that trigger it.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Environment / context
+      description: Versions, OS, config — anything relevant to the failure.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Keep the free-form "blank issue" option alongside the structured forms — not
+# every report fits bug/feature/spike.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,25 @@
+name: Feature / enhancement
+description: Propose a new feature or an improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: The problem or need — lead with the point, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What you'd build or change, and the alternatives you weighed.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: How we'll know it's done.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,25 @@
+name: Spike
+description: Time-boxed research or a decision to settle.
+labels: ["spike"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: The decision or unknown to resolve.
+    validations:
+      required: true
+  - type: input
+    id: timebox
+    attributes:
+      label: Timebox
+      description: How much time this is worth before deciding.
+    validations:
+      required: false
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Expected outcome
+      description: The artifact that ends the spike — an ADR, a comment, a follow-up issue.
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keeps the bundled workflow actions (checkout, git-cliff-action, etc.)
+  # current — applies to every repo that has .github/workflows, regardless
+  # of language. Language-specific ecosystems (npm, pip, ...) are a
+  # language overlay's concern, not this governance template's.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- Title = the Conventional Commit this squashes to: type(scope): imperative subject -->
+
+## Summary
+
+<!-- What changes and why — lead with the point. The problem, acceptance, and
+     design exploration live on the issue; link it, don't restate it. -->
+
+## Decision journal
+
+<!-- Decisions, gotchas, retractions, forks as they happened — the PR is the
+     real-time record. Drop this section if the change is trivial. -->
+
+## Verification
+
+<!-- What you ran, what it proved, and what's deliberately not covered. -->
+
+## Doc-ownership checklist
+
+<!-- Prompts, not gates. Tick, or strike through with a one-line reason. -->
+
+- [ ] Behavior or a convention changed → the docs that own it are updated in this PR.
+- [ ] Docs point at the enforcing config/rule, not restate it.
+- [ ] Architecturally significant or hard-to-reverse decision → an ADR under
+      `docs/adr/`, and this PR labeled `architecture` (see `docs/adr/README.md`
+      for _when_).
+- [ ] Reverses a recorded decision → the old ADR is marked `superseded by NNNN`,
+      not edited to match.
+
+Closes #

--- a/.github/workflows/adr-guard.yml
+++ b/.github/workflows/adr-guard.yml
@@ -1,0 +1,47 @@
+name: ADR guard
+
+# Architecture-labeled PRs must touch docs/adr/, or the decision goes
+# unrecorded. Checks presence only (label is a human call) — see docs/adr/README.md.
+on:
+  pull_request:
+    # labeled/unlabeled so applying or removing the label re-evaluates the gate;
+    # the rest match pr-guards.yml.
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adr-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  adr-guard:
+    name: adr guard
+    runs-on: ubuntu-latest
+    # Job-level if, not workflow-level: a workflow-level skip reads as passing to
+    # required-status-check branch protection. Stays quiet on drafts, fires at ready_for_review.
+    if: github.event.pull_request.draft == false
+    steps:
+      # Step-level if, not job-level: a required check must always report a
+      # conclusion, or a skipped run sits pending forever and blocks merge.
+      - uses: actions/checkout@v4
+        if: contains(github.event.pull_request.labels.*.name, 'architecture')
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Require a docs/adr/ touch on architecture-labeled PRs
+        if: contains(github.event.pull_request.labels.*.name, 'architecture')
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Three-dot: diff from the merge-base, so only files this PR changed
+          # count — not files the base branch changed after the PR forked.
+          if git diff --name-only "$BASE"...HEAD | grep -q '^docs/adr/'; then
+            echo "architecture-labeled PR touches docs/adr/ — ok."
+          else
+            echo "::error::PR is labeled 'architecture' but adds/modifies no docs/adr/ file. Record the decision as an ADR (see docs/adr/README.md) before merge."
+            exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,75 @@
+name: Lint
+
+# Language-agnostic linters only (lefthook `base` tag); an overlay ships its
+# own workflow/tag/toolchain instead. Disjoint file ownership — see ADR-0020.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    # Job-level if, not workflow-level: a workflow-level skip reads as passing to
+    # required-status-check branch protection. Same gate as pr-guards.yml.
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v4
+
+      # Portable toolchain, no Homebrew (#276): install each linter its native way
+      # instead of assuming Homebrew. `just lint` still drives the shared lefthook.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install Node lint tools
+        run: npm install --global lefthook markdownlint-cli2 prettier
+
+      - uses: extractions/setup-just@v3
+
+      - name: Install actionlint and yamlfmt
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          YAMLFMT_VERSION: "0.21.0"
+        run: |
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin actionlint
+          curl -fsSL "https://github.com/google/yamlfmt/releases/download/v${YAMLFMT_VERSION}/yamlfmt_${YAMLFMT_VERSION}_Linux_x86_64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin yamlfmt
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+
+      - name: Install shfmt and shellcheck
+        env:
+          SHFMT_VERSION: "3.13.1"
+          SHELLCHECK_VERSION: "0.11.0"
+        run: |
+          curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+            -o /tmp/shfmt && sudo install -m 755 /tmp/shfmt /usr/local/bin/shfmt
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | sudo tar -xJ -C /usr/local/bin --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+      - name: Install editorconfig-checker
+        env:
+          EDITORCONFIG_CHECKER_VERSION: "3.8.0"
+        run: |
+          curl -fsSL "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v${EDITORCONFIG_CHECKER_VERSION}/ec-linux-amd64.tar.gz" \
+            | tar -xz -O bin/ec-linux-amd64 | sudo tee /usr/local/bin/editorconfig-checker > /dev/null
+          sudo chmod +x /usr/local/bin/editorconfig-checker
+
+      # `just lint` is the same entry point contributors run locally, scoped
+      # here to the base tag; the untagged local run covers the full union.
+      - name: Run lint/format checks
+        run: just lint --tag base --no-tty

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -1,0 +1,43 @@
+name: PR code review (advisory)
+
+# Deliberately NOT a required status check: an LLM reviewer false-positives, and a
+# rate-limit/outage must never block a merge. Vendored DIY step from dotfiles (project-starter-template#60).
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for the review API key
+        id: guard
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "OPENAI_API_KEY not set — advisory review skipped." >&2
+            echo "enabled=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >>"$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@v4
+        if: steps.guard.outputs.enabled == 'true'
+      - uses: actions/setup-node@v4
+        if: steps.guard.outputs.enabled == 'true'
+        with:
+          node-version: "20"
+      - name: Advisory review
+        if: steps.guard.outputs.enabled == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_URL: https://openrouter.ai/api/v1/chat/completions
+          OPENAI_MODEL: openai/gpt-5.6-sol
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/pr-review/run.mjs

--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -1,0 +1,106 @@
+name: PR guards
+
+# Enforces one-commit-per-PR + rebase-merge (AGENTS.md): a single Conventional
+# Commit subject, and it closes an issue or declares why not (dotfiles#449).
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-guards-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  single-commit:
+    name: single commit
+    runs-on: ubuntu-latest
+    # Job-level if, not workflow-level: a workflow-level skip reads as passing to
+    # required-status-check branch protection. Stays quiet on drafts, fires at ready_for_review.
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Assert the PR is exactly one commit
+        env:
+          COMMITS: ${{ github.event.pull_request.commits }}
+        run: |
+          if [ "$COMMITS" -ne 1 ]; then
+            echo "::error::PR has $COMMITS commits; squash to exactly one before merge (git rebase origin/main && git reset --soft origin/main && git commit)."
+            exit 1
+          fi
+          echo "PR is a single commit."
+
+  conventional-commit:
+    name: conventional commit
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      # git-cliff reads this commit's subject for the changelog, so it must be
+      # a Conventional Commit; scope stays optional/unrestricted.
+      - name: Validate Conventional Commit subject
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          rc=0
+          for sha in $(git rev-list "$BASE"..HEAD); do
+            subject=$(git log -1 --format=%s "$sha")
+            if echo "$subject" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z0-9._-]+\))?!?: .+'; then
+              echo "ok: $subject"
+            else
+              echo "::error::not a Conventional Commit: $subject"
+              rc=1
+            fi
+          done
+          exit $rc
+
+  issue-link:
+    name: issue link
+    runs-on: ubuntu-latest
+    # release-prepare.yml's release/* PRs close no issue by design — exempted
+    # here in-guard so the whole contract stays in this one file (dotfiles#449).
+    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.head.ref, 'release/')
+    steps:
+      # GitHub's computed closingIssuesReferences (dotfiles#449), not a body
+      # regex, so a typo'd closing keyword that never actually linked fails this check.
+      - name: Require a closing issue reference or a No-Issue marker
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # shellcheck disable=SC2016 # single-quoted GraphQL vars, not bash
+          # ($owner/$repo/$number passed via -f/-F below).
+          count=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  closingIssuesReferences { totalCount }
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO" -F number="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.totalCount')
+
+          if [ "$count" -gt 0 ]; then
+            echo "closes $count issue(s) — ok."
+            exit 0
+          fi
+
+          # GNU grep \s/\S here, not dotfiles#449's POSIX space class: that
+          # class's double square brackets collide with this template's jinja delimiter.
+          if echo "$PR_BODY" | grep -qE '^No-Issue:\s*\S'; then
+            echo "No-Issue marker present — ok."
+            exit 0
+          fi
+
+          echo "::error::PR closes no issue and has no No-Issue: marker. Add \`Closes #N\` to the body, or a \`No-Issue: <reason>\` line."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# git-flow governance template — see README for what this covers.
+# A language overlay's own .gitignore needs hand-merging with this one;
+# copier can't merge text files across templates.
+.envrc.local

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Config for lefthook-base.yml's gitleaks job. Extends the default
+# ruleset; this file only adds allowlists. dir-mode scanning has no git
+# awareness, so the gitignored local-credential file must be allowlisted
+# here — otherwise a checkout with a real token in .envrc.local can never
+# commit. Lineage: dotfiles' own .gitleaks.toml (dotfiles#390).
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "gitignored local credentials"
+paths = ['''\.envrc\.local$''']

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,10 @@
+config:
+  # Prose line length; long tables, code blocks, and headings are exempt.
+  MD013:
+    line_length: 100
+    code_blocks: false
+    tables: false
+    headings: false
+  # Generated docs and ADRs may open with a badge line or front matter before
+  # the H1 — don't force the first line to be a top-level heading.
+  MD041: false

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "preserve"
+}

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,6 @@
+formatter:
+  retain_line_breaks: true
+  # Keep intentionally-wrapped `>-` folded scalars as written instead of
+  # collapsing them onto one line — retain_line_breaks doesn't reach inside
+  # folded scalars (dotfiles#409).
+  scan_folded_as_literal: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# AGENTS.md
+
+Precedence: this repo's own docs win over the generic agent-config rules where they conflict.
+
+## What this is
+
+See `README.md` for what this repo is and how it's consumed.
+
+<!-- TODO: once claude/{rules,agents,skills} content lands (carpet-stain/dotfiles#567 — see issue
+#3's non-goals), expand this with the directory layout and how a consuming repo wires the
+submodule in. -->
+
+## Commits — Conventional Commits
+
+> Concrete realization of **git.md** (Commits — Conventional Commits) for this repo.
+
+`type(scope): description`, imperative lowercase subject ≤50 chars (hard limit 72); `type` ∈
+feat/fix/docs/style/refactor/perf/test/build/ci/chore; `scope` ∈ `docs`, `scripts` — confirm
+before relying on this list, it's thin until real content lands. Breaking change: `type!:` or a
+`BREAKING CHANGE:` footer. Blank line, then a body wrapped at 72 explaining _what_ and _why_,
+never _how_. `Co-authored-by:` per human contributor; never AI attribution. One logical change per
+commit; propose the split before committing.
+
+Enforced by `.github/workflows/pr-guards.yml` (CI-only, no local mirror yet) — see it for the
+exact type/subject checks that block a merge.
+
+## Version Control Discipline
+
+- Don't commit or push on your own initiative — show what changed, get approval, commit only that.
+- Commit freely on the working branch; main-line history stays clean (one squashed commit per
+  merged change, not its iteration history).
+- Rebase onto latest `main` before merging.
+- Never rewrite history you don't own. The only sanctioned force-push is your own just-squashed
+  branch, and it aborts if the remote moved. If the remote moved unexpectedly, stop and inspect
+  before anything destructive — realign, don't overwrite.
+
+## Branch & PR model — short-lived feature branches + protected `main`, rebase-merged
+
+> Concrete realization of **git.md** (Branch & PR model) for this repo, confirmed by the
+> `pr-guards.yml` CI signal (single-commit + Conventional-Commit-subject gate).
+
+1. Fetch and check `main` before branching — a stale base means painful divergence later. Branch
+   off it per change; the branch is single-use and short-lived.
+2. Open the PR as soon as a branch and first commit exist, not after the final squash (`gh pr
+create --draft`). Journal decisions, gotchas, decision forks, and retractions as PR comments
+   while work proceeds — the PR becomes the real-time record, not a postmortem written at the end.
+   `pr-guards.yml` stays quiet on a draft PR and evaluates for real once it's marked ready.
+3. Commit freely on the feature branch — WIP commits needn't follow the commit style, since only
+   the final squashed commit reaches `main`.
+4. One logical change per PR. Never bundle unrelated changes to save a round trip.
+5. When ready and tested, squash the branch to exactly one Conventional Commit
+   (`git reset --soft origin/main && git commit`), then mark ready for review — the commit reaches
+   its final shape here, and `pr-guards.yml` gates on the PR being exactly one commit with a
+   Conventional-Commit subject. Rewrite the PR body to stand alone: what changed and why,
+   deviations from any prior plan, verification done — a reviewer derives the whole change from a
+   one-minute read of the top post, no thread required.
+6. Once green, **rebase-merge**: the single commit lands on `main` verbatim, and the branch
+   auto-deletes.
+7. `main` stays releasable, never committed to directly. Merge method is rebase-merge only,
+   enforced by the single-commit + Conventional-Commit checks.
+
+A PR labeled `architecture` must add or modify a `docs/adr/` file — see
+[`docs/adr/README.md`](docs/adr/README.md) for when a decision warrants one; `adr-guard.yml`
+enforces only the presence, not the judgment call.
+
+## Working iteratively when you can't self-verify
+
+Open-PR-early (step 2 above) still applies regardless of how verifiable the change is: always
+open via `gh pr create --draft`, never the plain path, even when the change is already done and
+verified. Draft means the agent is still working, ready-for-review means it's the human's turn —
+squash to one commit and mark ready at that handoff for all work, verifiable or not. For changes
+that can't be confirmed alone (GUI, TUI, rendering, keybindings), the human's confirmation folds
+into reviewing the ready PR rather than gating the flip to ready. Staying in draft at handoff is
+the exception, not the default: only when the agent specifically needs the human to test something
+_before_ code review can happen, and it says so in the handoff message.
+
+## Shift-left tooling and credential scope
+
+> Concrete realization of **git.md** (Shift-left tooling) and **github.md** (Local tooling,
+> Credentials) for this repo.
+
+- `just lint` (wraps `lefthook run pre-commit --all-files`) mirrors what CI's `lint` job runs —
+  run it before pushing. `just adr "<title>"` stamps a numbered ADR from the template. `just
+format` fixes what `lefthook`'s `md-format` job only checks (deliberately a recipe, not a hook).
+- `gh` should run under a scoped-down token (contents/PRs/actions read-write, no Administration)
+  for routine work — see `.envrc.local.example` for the credential pattern (`GH_TOKEN` aliased to
+  `GITHUB_TOKEN`). Elevate explicitly (`env -u GH_TOKEN -u GITHUB_TOKEN gh ...`) only for the one
+  action that needs admin scope (branch protection, labels).
+- `act` runs the Actions workflows locally via Docker, for testing without pushing.
+
+## Releases
+
+Not wired up — `include_release_automation=false` at scaffold time (#3): this repo is consumed as
+a submodule tracking `main`, no SemVer releases yet. Flip that copier answer later (see
+`project-starter-template`'s `git-flow` template) if versioned releases are ever wanted.
+
+## Structure & conventions
+
+<!-- TODO: once claude/{rules,agents,skills} content lands, document the directory layout and
+naming conventions here. Currently just the git-flow governance scaffold: .github/, docs/adr/,
+scripts/, lefthook/justfile composition. -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # agents
-Shared AI-agent definitions — personas, universal rules, skills, the memory contract. Provider-neutral markdown, consumed per-project
+
+Shared AI-agent definitions — personas, universal rules, skills, the memory contract.
+Provider-neutral markdown, consumed per-project.
+
+## Use
+
+Consumed as a submodule by downstream repos (e.g. `carpet-stain/dotfiles`), not run
+standalone.
+
+## Contributing
+
+The contributor guide — workflow, commit rules, tooling, credentials — lives in
+`AGENTS.md` (composed from your agent-config rules; generate it if it isn't
+present yet). Architecture decisions live in
+[`docs/adr/`](docs/adr/README.md). This README is the human front door and
+points at those homes rather than restating them.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,40 @@
+# 1. Record architecture decisions
+
+Date: DATE
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architecturally significant decisions made on this
+project — what was chosen, what was rejected, and why — so the design history is
+walkable later instead of excavated from closed issues and PRs. Without a durable
+home, the _why_ behind a decision gets re-litigated every time someone questions
+it.
+
+## Decision
+
+Use Architecture Decision Records, as [described by Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+ADRs live in `docs/adr/`, are numbered sequentially, and follow
+[`templates/template.md`](templates/template.md): Status, Context, Decision,
+Alternatives considered, Consequences. Manage them with
+[adr-tools](https://github.com/npryce/adr-tools) — see
+[`README.md`](README.md) for the workflow.
+
+## Alternatives considered
+
+- **No formal record** — leave decisions in issues, PRs, and commit messages.
+  Rejected: the _why_ scatters across closed threads and can't be walked; it's
+  the exact excavation problem ADRs exist to solve.
+- **A single running design doc** — one file everyone edits. Rejected: it loses
+  the per-decision status and superseding history, and rejected alternatives get
+  overwritten rather than staying visible.
+
+## Consequences
+
+Every significant decision leaves a distilled, durable record. `adr-guard.yml`
+enforces that a PR labeled `architecture` ships one. Superseding a decision links
+the old and new ADRs rather than editing history, so the rejected path stays
+visible.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,39 @@
+# Architecture Decision Records
+
+Each ADR records one significant decision — what we chose, what we considered
+and **rejected**, and why — as a durable, walkable file, so the design history
+doesn't have to be excavated from closed issues and PRs.
+
+## When to write one
+
+Write an ADR when a decision is architecturally significant, cross-cutting,
+long-lived, or expensive to reverse. A small, local, easily-reversed choice is a
+PR description or a code comment, not an ADR — don't turn `docs/adr/` into a
+dumping ground.
+
+`adr-guard.yml` enforces only the _presence_ of a record: a PR labeled
+`architecture` must add or modify a file here. The judgment of whether a change
+_is_ architectural stays human — it's applied by adding the label.
+
+## Creating one
+
+Create ADRs with the shipped tool — never hand-number or hand-format them.
+`scripts/new-adr.sh` stamps the next sequential number and fills
+[`templates/template.md`](templates/template.md); the `just adr` recipe wraps it:
+
+```sh
+just adr "Short decision title"       # next-numbered ADR from the template
+```
+
+It's a plain, runner-agnostic script rather than adr-tools (which has no Debian
+package), so it works on any machine the repo runs on. Then edit the generated
+file and fill in the sections. The **Alternatives considered** section — each
+rejected option and _why_ — is the point: it's what makes the design history
+walkable.
+
+## Superseding
+
+When a later decision replaces an earlier one, create the new ADR, then set the
+old one's Status to `Superseded by NNNN` (and the new one's to `Supersedes NNNN`)
+rather than editing the old ADR to match the new reality. The rejected path
+staying visible is the point.

--- a/docs/adr/templates/template.md
+++ b/docs/adr/templates/template.md
@@ -1,0 +1,24 @@
+# NUMBER. TITLE
+
+Date: DATE
+
+## Status
+
+STATUS
+
+## Context
+
+What forces are at play — the problem, constraints, why it needs a decision now.
+
+## Decision
+
+What we're doing, stated plainly.
+
+## Alternatives considered
+
+- **Option A** — why rejected.
+- **Option B** — why rejected.
+
+## Consequences
+
+What gets easier or harder as a result; what to revisit if a premise changes.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+# Composition root — base-owned, never edited by an overlay (ADR-0020 in the
+# template's source repo). Base verbs live in justfile.base; a language
+# overlay drops its verbs in justfile.lang and the optional import picks it
+# up — absent in a base-only repo, active the moment the overlay lands.
+# justfile.release is the same optional-import shape, gated on
+# include_release_automation instead of a language overlay.
+
+import 'justfile.base'
+import? 'justfile.lang'
+import? 'justfile.release'
+
+# List recipes when invoked with no arguments.
+_default:
+    @just --list

--- a/justfile.base
+++ b/justfile.base
@@ -1,0 +1,21 @@
+# Base verbs — owned by the git-flow template; overlays add theirs in
+# justfile.lang, never here. `lint` is the shared entry point: CI's lint job
+# runs it scoped to `--tag base`; locally, unfiltered, it runs every layer's
+# checks.
+
+# Run every pre-commit check (CI's lint job runs `just lint --tag base`).
+lint *args:
+    lefthook run pre-commit --all-files {{ args }}
+
+# Create a numbered ADR from the template: `just adr "Short decision title"`.
+adr *args:
+    scripts/new-adr.sh {{ args }}
+
+# Auto-format markdown with prettier (fixes what md-format only checks).
+# Manual, deliberately NOT a lefthook job: `just lint` (and CI's lint job) run
+# `lefthook run pre-commit --all-files`, and `prettier --write` always exits 0
+# — hooking it would make md-format stop gating format in CI (dotfiles#406).
+# Scoped via git ls-files to tracked markdown only, mirroring md-format's
+# excludes (CHANGELOG is git-cliff-generated, agent-memory is heredoc notes).
+format:
+    git ls-files -z '*.md' ':!:CHANGELOG.md' ':!:.claude/agent-memory/**' | xargs -0 prettier --write

--- a/lefthook-base.yml
+++ b/lefthook-base.yml
@@ -1,0 +1,105 @@
+# Base lefthook jobs — owned by the git-flow template; a language overlay
+# never edits this file (its jobs live in lefthook-lang.yml). The `base` tag
+# is what lint.yml's CI job selects; keep it on every job here.
+pre-commit:
+  jobs:
+    - name: actionlint
+      tags: [base]
+      glob:
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+      run: actionlint {staged_files}
+
+    - name: md-format
+      tags: [base]
+      glob:
+        - "*.md"
+        - "**/*.md"
+      exclude:
+        - "CHANGELOG.md"
+        - ".claude/agent-memory/**"
+      run: prettier --check {staged_files}
+
+    - name: markdownlint
+      tags: [base]
+      glob:
+        - "*.md"
+        - "**/*.md"
+      exclude:
+        - "CHANGELOG.md"
+        - ".claude/agent-memory/**"
+      run: markdownlint-cli2 {staged_files}
+
+    - name: yaml-format
+      tags: [base]
+      glob:
+        - ".github/dependabot.yml"
+        - ".markdownlint-cli2.yaml"
+        - "lefthook.yml"
+        - "lefthook-base.yml"
+        - "lefthook-lang.yml"
+      run: yamlfmt -lint {staged_files}
+
+    - name: gitleaks
+      tags: [base]
+      # No glob/{staged_files} — content-based scan must cover
+      # .claude/agent-memory/**; never add the markdown exclude list here. Lineage: dotfiles#390.
+      run: gitleaks dir . --no-banner --redact
+
+    - name: shfmt
+      tags: [base]
+      glob:
+        - "scripts/*.sh"
+      run: shfmt -i 2 -ci -d {staged_files}
+
+    - name: shellcheck
+      tags: [base]
+      # No zsh exclude (dotfiles has one for false positives) — this repo ships no zsh.
+      # .envrc/.envrc.local.example carry `# shellcheck shell=bash` since they lack a shebang.
+      glob:
+        - "scripts/*.sh"
+        - ".envrc"
+        - ".envrc.local.example"
+      run: shellcheck {staged_files}
+
+    - name: comment-concision
+      tags: [base]
+      glob:
+        - "scripts/*.sh"
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+        - "lefthook.yml"
+        - "lefthook-base.yml"
+        - "lefthook-lang.yml"
+      run: scripts/check-comment-concision.sh {staged_files}
+
+    - name: justfile-format
+      tags: [base]
+      glob:
+        - "justfile"
+        - "justfile.base"
+      # --justfile takes exactly one path; this repo has two real justfiles, so
+      # xargs -n1 runs the check per file instead of passing both at once.
+      run: echo {staged_files} | xargs -n1 just --fmt --check --justfile
+
+    - name: editorconfig-checker
+      tags: [base]
+      glob:
+        - "*"
+        - "**/*"
+      exclude:
+        - "CHANGELOG.md"
+        - ".claude/agent-memory/**"
+      # --disable-indentation: indentation stays each per-language formatter's
+      # job (shfmt/prettier/yamlfmt) — this checker is only the catch-all for the rest.
+      run: editorconfig-checker --disable-indentation {staged_files}
+
+    - name: envrc-local-example-sync
+      tags: [base]
+      run: scripts/check-envrc-local-example.sh
+
+pre-push:
+  jobs:
+    - name: envrc-local-example-sync
+      tags: [base]
+      run: scripts/check-envrc-local-example.sh

--- a/lefthook-lang.yml
+++ b/lefthook-lang.yml
@@ -1,0 +1,3 @@
+# Language-overlay socket — intentionally empty in the base. A language
+# overlay overwrites this file with its jobs (tagged `lang`); lefthook.yml's
+# `extends` picks it up either way. Never put base jobs here.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+# Composition root — base-owned, never edited by an overlay (ADR-0020 in the
+# template's source repo). Base jobs live in lefthook-base.yml (tagged
+# `base`); lefthook-lang.yml ships here as an empty stub a language overlay
+# overwrites with its jobs (tagged `lang`). Locally every layer's jobs run on
+# commit/push; each CI workflow runs only its own tag slice. Install with
+# `lefthook install`.
+extends:
+  - lefthook-base.yml
+  - lefthook-lang.yml

--- a/scripts/check-comment-concision.sh
+++ b/scripts/check-comment-concision.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Blocking signpost cap, not a length nudge — see dotfiles ADR-0044
+# (supersedes ADR-0031). THRESHOLD_LINES is the max allowed, so the
+# comparison is `>`, not `>=`.
+set -uo pipefail
+
+THRESHOLD_LINES=2
+
+comment_prefix_for() {
+  case "$1" in
+    *.sh | *.yml | *.yaml) echo '#' ;;
+    # Conditional-named jinja files (e.g. `{% if x %}foo.yml{% endif %}.jinja`)
+    # put `.yml`/`.yaml` mid-filename, not as a clean suffix.
+    *.yml*.jinja | *.yaml*.jinja) echo '#' ;;
+    *) echo '' ;;
+  esac
+}
+
+status=0
+
+for file in "$@"; do
+  [[ -f "$file" ]] || continue
+  prefix=$(comment_prefix_for "$file")
+  [[ -n "$prefix" ]] || continue
+
+  awk -v prefix="$prefix" -v threshold="$THRESHOLD_LINES" -v file="$file" '
+    function report() {
+      if (count == 0) return
+      # Out of scope: the file-header preamble (first block, nothing above it
+      # but a shebang or blanks) and ASCII banners — no why in either to relocate.
+      if (!seen_code && !header_seen) { header_seen = 1; return }
+      if (banner_lines == count) return
+      if (count > threshold) {
+        printf "%s:%d: %d-line comment block on one declaration — cap is %d (tripwire + pointer); relocate the why to its ADR/issue home (design-principles.md)\n", file, start, count, threshold
+        found = 1
+      }
+    }
+    NR == 1 && $0 ~ /^#!/ { next }
+    $0 ~ ("^[ \t]*" prefix "([ \t]|$)") {
+      if (count == 0) { start = NR; banner_lines = 0 }
+      count++
+      body = $0
+      sub("^[ \t]*" prefix "[ \t]*", "", body)
+      sub("[ \t]*$", "", body)
+      if (body ~ /^\+-+\+$/ || body ~ /^\|.*\|$/) banner_lines++
+      next
+    }
+    { report(); count = 0; banner_lines = 0; if ($0 !~ /^[ \t]*$/) seen_code = 1 }
+    END { report(); exit found ? 1 : 0 }
+  ' "$file" || status=1
+done
+
+exit "$status"

--- a/scripts/check-envrc-local-example.sh
+++ b/scripts/check-envrc-local-example.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Enforces two invariants for .envrc.local.example (the tracked template for
+# the gitignored .envrc.local):
+#   1. Every export line's value is empty. This is what actually guarantees
+#      no real credential can land here, rather than pattern-matching
+#      against what a "real-looking" secret happens to look like today.
+#   2. It matches .envrc.local structurally (comments, variable names) once
+#      values are stripped, so the template can't silently drift from what
+#      is actually needed.
+set -uo pipefail
+
+example_file=".envrc.local.example"
+real_file=".envrc.local"
+
+# [A-Z0-9_], not [A-Z_]: excluding digits would let a var like R2_... skip
+# stripping, and the diff below prints unstripped values to stderr.
+strip_values() { sed -E 's/^(export [A-Z0-9_]+=).*/\1/' "$1"; }
+
+if grep -E '^export [A-Z0-9_]+=.+' "$example_file" >/dev/null; then
+  echo "error: $example_file has a non-empty export value — replace it with 'export VAR=' (empty)" >&2
+  exit 1
+fi
+
+# Nothing to compare the template's shape against if .envrc.local doesn't
+# exist locally (e.g. CI, or not set up yet on this machine).
+[[ -f "$real_file" ]] || exit 0
+
+if ! diff_output="$(diff -u <(strip_values "$real_file") <(strip_values "$example_file"))"; then
+  echo "error: $example_file has drifted from $real_file (beyond credential values):" >&2
+  echo "$diff_output" >&2
+  exit 1
+fi

--- a/scripts/new-adr.sh
+++ b/scripts/new-adr.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Stamp a sequentially-numbered ADR from docs/adr/templates/template.md — the
+# runner-agnostic replacement for adr-tools, which has no Debian package and so
+# isn't portable across the machines a bootstrapped repo runs on. Numbers
+# auto-increment from the highest existing docs/adr/NNNN-*.md so ADRs are never
+# hand-numbered. Run via `just adr "Title"`.
+#
+# usage: scripts/new-adr.sh "Short decision title"
+set -euo pipefail
+
+ADR_DIR="docs/adr"
+TEMPLATE="$ADR_DIR/templates/template.md"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 \"Short decision title\"" >&2
+  exit 1
+fi
+TITLE="$*"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "error: ADR template not found at $TEMPLATE" >&2
+  exit 1
+fi
+
+# Highest existing NNNN prefix, or 0 so the first real ADR after the seed is
+# numbered one past it. 10# forces base-10 so a leading zero isn't read as octal.
+last=$(find "$ADR_DIR" -maxdepth 1 -name '[0-9][0-9][0-9][0-9]-*.md' -exec basename {} \; |
+  sort | tail -n1 | cut -c1-4)
+next=$(printf '%04d' $((10#${last:-0} + 1)))
+
+# Slug: lowercase, spaces/underscores to hyphens, drop other punctuation,
+# collapse repeats, trim leading/trailing hyphens.
+slug=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | tr ' _' '--' |
+  tr -cd 'a-z0-9-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
+file="$ADR_DIR/${next}-${slug}.md"
+
+# Fill the template's placeholders; leave the body sections for the author.
+sed -e "s/^# NUMBER\. TITLE/# ${next}. ${TITLE}/" \
+  -e "s/^Date: DATE/Date: $(date +%Y-%m-%d)/" \
+  -e "s/^STATUS/Accepted/" \
+  "$TEMPLATE" >"$file"
+
+echo "created $file — edit it to fill in Context, Decision, Alternatives, Consequences."

--- a/scripts/pr-review/build-review.mjs
+++ b/scripts/pr-review/build-review.mjs
@@ -1,0 +1,144 @@
+// Turns parsed diff line maps + the model's structured findings into the
+// `comments` array `pulls.createReview` expects. Pure, no I/O — see
+// build-review.test.mjs. run.mjs is the only caller that does real I/O.
+
+import { parsePatch } from "./diff.mjs";
+
+// Ordering + the set of accepted severities (a finding with any other value
+// is dropped). "recommended" is the should-fix-but-not-blocking middle rung;
+// "pre-existing" is a real issue the diff didn't introduce, flagged last.
+const SEVERITY_RANK = { blocking: 0, recommended: 1, nit: 2, "pre-existing": 3 };
+
+// Bound cost and prompt size: only this many files, and this many prompt
+// characters total, go to the model. A PR bigger than this gets a partial
+// review (first MAX_FILES files, truncated at MAX_PROMPT_CHARS) rather than
+// an unbounded request — see #330's discussion for why a hard cap beats
+// dynamic chunking here.
+export const MAX_FILES = 25;
+export const MAX_PROMPT_CHARS = 12000;
+
+// Bound the intent context (PR description + linked issue bodies) fed to the
+// model alongside the diff. Issue bodies here can be long — for a
+// plan-approved issue, the body is the consolidated plan and acceptance
+// criteria (backlog-manager's plan-review gate), which is exactly what a
+// conformance review needs to check the diff against.
+export const MAX_ISSUES = 3;
+export const MAX_PR_BODY_CHARS = 2000;
+export const MAX_ISSUE_BODY_CHARS = 3000;
+
+/**
+ * Decides whether a PR should get the advisory review (#458): auto-triggers
+ * when it closes an issue carrying `plan-approved` — this repo's plan-review
+ * gate consolidates the approved plan + acceptance criteria into that
+ * issue's body, exactly what a conformance review needs — or on demand via
+ * the PR's own `needs-review` label (#456), independent of `architecture`'s
+ * ADR-required meaning.
+ * @param {string[]} prLabels - the PR's own label names
+ * @param {{labels: string[]}[]} issues - issues the PR closes, each with its label names
+ * @returns {boolean}
+ */
+export function isEligibleForReview(prLabels, issues = []) {
+  return prLabels.includes("needs-review") || issues.some((issue) => issue.labels.includes("plan-approved"));
+}
+
+/**
+ * Renders the "Intent" block prepended to the review prompt: the PR's
+ * title/description and the bodies of issues it closes (sourced from
+ * GraphQL `closingIssuesReferences`, not a body-text regex — run.mjs's
+ * `fetchPrContext`), each length-capped. This is the plan the model checks
+ * the diff against — NOT trusted as proof the work is done (see the system
+ * prompt). Returns "" when there's no PR context.
+ * @param {{title?: string, body?: string}|null} pr
+ * @param {{number: number, title: string, body?: string}[]} issues
+ * @returns {string}
+ */
+export function buildContext(pr, issues = []) {
+  if (!pr) return "";
+  let out = "## Intent — the diff claims to implement this plan; flag divergences from the stated approach and unmet acceptance criteria\n";
+  if (pr.title) out += `\nPR: ${pr.title}\n`;
+  if (pr.body) out += `\n${pr.body.trim().slice(0, MAX_PR_BODY_CHARS)}\n`;
+  for (const issue of issues) {
+    out += `\nLinked issue #${issue.number}: ${issue.title}\n`;
+    if (issue.body) out += `${issue.body.trim().slice(0, MAX_ISSUE_BODY_CHARS)}\n`;
+  }
+  return out.trim();
+}
+
+/**
+ * @param {{filename: string, patch?: string}[]} files - GitHub's
+ *   pulls.listFiles response entries.
+ * @returns {{filename: string, lines: Map<number,string>}[]} text files
+ *   only (binary/too-large files carry no `patch` and are dropped), capped
+ *   at MAX_FILES.
+ */
+export function parseFiles(files) {
+  return files
+    .filter((f) => f.patch)
+    .slice(0, MAX_FILES)
+    .map((f) => ({ filename: f.filename, lines: parsePatch(f.patch) }));
+}
+
+/**
+ * Renders the annotated-line-number prompt section the model sees: each
+ * commentable line prefixed with its exact new-file line number, so the
+ * model's response can only reference line numbers we already know are
+ * valid review-comment anchors.
+ */
+export function buildPrompt(parsedFiles) {
+  let out = "";
+  for (const { filename, lines } of parsedFiles) {
+    let section = `File: ${filename}\n`;
+    for (const [line, content] of lines) {
+      section += `${line}: ${content}\n`;
+    }
+    if (out.length + section.length > MAX_PROMPT_CHARS) {
+      // A first file whose section alone overflows the budget still gets a
+      // truncated slice, so a large single-file PR is reviewed partially
+      // rather than not at all. buildReviewComments validates every finding
+      // against the full parsed line map, so a mid-line cut here can't post
+      // a comment on a bogus anchor.
+      if (out.length === 0) {
+        out = section.slice(0, MAX_PROMPT_CHARS);
+      }
+      out += "\n[truncated — remaining files omitted to bound prompt size]\n";
+      break;
+    }
+    out += `\n${section}`;
+  }
+  return out.trim();
+}
+
+/**
+ * Validates model findings against the actual diff (defense against a
+ * hallucinated file/line/severity) and renders each into a review comment
+ * body. Findings that don't anchor to a real diff line are dropped rather
+ * than posted — GitHub's createReview API would 422 the whole review on a
+ * single bad anchor otherwise.
+ *
+ * @param {{filename: string, lines: Map<number,string>}[]} parsedFiles
+ * @param {{file: string, line: number, severity: string, comment: string, suggestion?: string|null}[]} findings
+ * @returns {{comments: {path: string, line: number, side: 'RIGHT', body: string}[], dropped: number}}
+ */
+export function buildReviewComments(parsedFiles, findings) {
+  const byFile = new Map(parsedFiles.map((f) => [f.filename, f.lines]));
+  let dropped = 0;
+
+  const valid = findings.filter((f) => {
+    const lines = byFile.get(f.file);
+    const ok = Boolean(lines) && lines.has(f.line) && SEVERITY_RANK[f.severity] !== undefined;
+    if (!ok) dropped++;
+    return ok;
+  });
+
+  valid.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);
+
+  const comments = valid.map((f) => {
+    let body = `**${f.severity}**: ${f.comment}`;
+    if (f.suggestion) {
+      body += `\n\n\`\`\`suggestion\n${f.suggestion}\n\`\`\``;
+    }
+    return { path: f.file, line: f.line, side: "RIGHT", body };
+  });
+
+  return { comments, dropped };
+}

--- a/scripts/pr-review/build-review.test.mjs
+++ b/scripts/pr-review/build-review.test.mjs
@@ -1,0 +1,176 @@
+// Unit tests for the pure diff-parsing / review-building logic, run with
+// Node's built-in test runner (no dependency, no package.json needed):
+//   node --test scripts/pr-review/*.test.mjs
+//
+// This is the isolation-testable half of the DIY PR reviewer (#330) — the
+// I/O half (run.mjs: real GitHub/OpenAI calls) can only really prove out
+// on a live PR run, per this repo's AGENTS.md verification guidance.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parsePatch } from "./diff.mjs";
+import {
+  parseFiles,
+  buildPrompt,
+  buildReviewComments,
+  buildContext,
+  isEligibleForReview,
+  MAX_PROMPT_CHARS,
+  MAX_ISSUE_BODY_CHARS,
+} from "./build-review.mjs";
+
+const SAMPLE_PATCH = [
+  "@@ -10,3 +10,4 @@ function greet() {",
+  " function greet() {",
+  "-  console.log('hi')",
+  "+  console.log('hello')",
+  "+  return true",
+  " }",
+].join("\n");
+
+test("parsePatch maps RIGHT-side line numbers, skips removed lines", () => {
+  const lines = parsePatch(SAMPLE_PATCH);
+  assert.equal(lines.get(10), "function greet() {");
+  assert.equal(lines.get(11), "  console.log('hello')");
+  assert.equal(lines.get(12), "  return true");
+  assert.equal(lines.get(13), "}");
+  assert.equal(lines.size, 4);
+});
+
+test("parsePatch returns an empty map for a binary/no-patch file", () => {
+  assert.equal(parsePatch(undefined).size, 0);
+  assert.equal(parsePatch("").size, 0);
+});
+
+test("parsePatch keeps line numbers in sync across a blank context line", () => {
+  // A blank unchanged line is a bare " " (leading-space marker) in a unified
+  // diff — it must map to its line number and advance the counter, or every
+  // later anchor desyncs.
+  const patch = ["@@ -1,4 +1,4 @@", " first", " ", "-old", "+new"].join("\n");
+  const lines = parsePatch(patch);
+  assert.equal(lines.get(1), "first");
+  assert.equal(lines.get(2), ""); // blank context line, still counted
+  assert.equal(lines.get(3), "new"); // stays line 3, not shifted to 2
+  assert.equal(lines.size, 3);
+});
+
+test("parsePatch handles multiple hunks in one file", () => {
+  const patch = ["@@ -1,2 +1,2 @@", " a", "+b", "@@ -10,2 +20,2 @@", " x", "+y"].join("\n");
+  const lines = parsePatch(patch);
+  assert.equal(lines.get(1), "a");
+  assert.equal(lines.get(2), "b");
+  assert.equal(lines.get(20), "x");
+  assert.equal(lines.get(21), "y");
+  assert.equal(lines.size, 4);
+});
+
+test("parseFiles drops binary/no-patch files", () => {
+  const files = [
+    { filename: "a.ts", patch: SAMPLE_PATCH },
+    { filename: "b.png", patch: undefined },
+  ];
+  const parsed = parseFiles(files);
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].filename, "a.ts");
+});
+
+test("buildPrompt renders annotated line numbers per file", () => {
+  const parsed = parseFiles([{ filename: "a.ts", patch: SAMPLE_PATCH }]);
+  const prompt = buildPrompt(parsed);
+  assert.match(prompt, /File: a\.ts/);
+  assert.match(prompt, /11:   console\.log\('hello'\)/);
+});
+
+test("buildPrompt still includes a truncated slice when the first file alone exceeds the cap", () => {
+  // A single file bigger than the whole budget must be reviewed partially,
+  // not skipped into an empty prompt (which would silently review nothing).
+  const lines = new Map();
+  const lineLen = 40;
+  for (let i = 1; i <= Math.ceil((MAX_PROMPT_CHARS * 2) / lineLen); i++) {
+    lines.set(i, "x".repeat(lineLen));
+  }
+  const prompt = buildPrompt([{ filename: "big.ts", lines }]);
+  assert.ok(prompt.length > 0, "prompt must not be empty");
+  assert.match(prompt, /File: big\.ts/);
+  assert.match(prompt, /\[truncated/);
+});
+
+test("buildReviewComments keeps findings anchored to real diff lines, drops hallucinated ones", () => {
+  const parsed = parseFiles([{ filename: "a.ts", patch: SAMPLE_PATCH }]);
+  const findings = [
+    {
+      file: "a.ts",
+      line: 11,
+      severity: "nit",
+      comment: "use a template literal here",
+      suggestion: "  console.log(`hello`)",
+    },
+    { file: "a.ts", line: 999, severity: "blocking", comment: "hallucinated line", suggestion: null },
+    { file: "missing.ts", line: 1, severity: "nit", comment: "hallucinated file", suggestion: null },
+  ];
+  const { comments, dropped } = buildReviewComments(parsed, findings);
+  assert.equal(comments.length, 1);
+  assert.equal(dropped, 2);
+  assert.equal(comments[0].path, "a.ts");
+  assert.equal(comments[0].line, 11);
+  assert.equal(comments[0].side, "RIGHT");
+  assert.match(comments[0].body, /```suggestion\n {2}console\.log\(`hello`\)\n```/);
+});
+
+test("buildReviewComments sorts blocking < recommended < nit < pre-existing", () => {
+  const parsed = parseFiles([{ filename: "a.ts", patch: SAMPLE_PATCH }]);
+  const findings = [
+    { file: "a.ts", line: 10, severity: "nit", comment: "n", suggestion: null },
+    { file: "a.ts", line: 11, severity: "blocking", comment: "b", suggestion: null },
+    { file: "a.ts", line: 12, severity: "pre-existing", comment: "p", suggestion: null },
+    { file: "a.ts", line: 13, severity: "recommended", comment: "r", suggestion: null },
+  ];
+  const { comments } = buildReviewComments(parsed, findings);
+  assert.deepEqual(
+    comments.map((c) => c.line),
+    [11, 13, 10, 12],
+  );
+});
+
+test("buildReviewComments drops a finding with an unknown severity", () => {
+  const parsed = parseFiles([{ filename: "a.ts", patch: SAMPLE_PATCH }]);
+  const findings = [{ file: "a.ts", line: 10, severity: "catastrophic", comment: "x", suggestion: null }];
+  const { comments, dropped } = buildReviewComments(parsed, findings);
+  assert.equal(comments.length, 0);
+  assert.equal(dropped, 1);
+});
+
+test("buildContext renders PR title/body and linked issues, empty for no PR", () => {
+  const ctx = buildContext(
+    { title: "feat: add widget", body: "Adds the widget.\nCloses #5" },
+    [{ number: 5, title: "Need a widget", body: "We should have a widget." }],
+  );
+  assert.match(ctx, /## Intent/);
+  assert.match(ctx, /PR: feat: add widget/);
+  assert.match(ctx, /Adds the widget\./);
+  assert.match(ctx, /Linked issue #5: Need a widget/);
+  assert.match(ctx, /We should have a widget\./);
+  assert.equal(buildContext(null), "");
+});
+
+test("buildContext caps an over-long issue body", () => {
+  const huge = "y".repeat(MAX_ISSUE_BODY_CHARS * 2);
+  const ctx = buildContext({ title: "t" }, [{ number: 1, title: "big", body: huge }]);
+  assert.ok(!ctx.includes(huge), "full oversized body must not appear verbatim");
+  assert.ok(ctx.includes("y".repeat(MAX_ISSUE_BODY_CHARS)), "a capped slice should appear");
+});
+
+test("isEligibleForReview triggers on the PR's own needs-review label", () => {
+  assert.equal(isEligibleForReview(["needs-review"], []), true);
+  assert.equal(isEligibleForReview(["architecture"], []), false);
+});
+
+test("isEligibleForReview triggers when a closed issue carries plan-approved", () => {
+  assert.equal(isEligibleForReview([], [{ labels: ["plan-approved"] }]), true);
+  assert.equal(isEligibleForReview([], [{ labels: ["needs-plan-review"] }]), false);
+});
+
+test("isEligibleForReview is false when neither the label nor a closed issue qualifies", () => {
+  assert.equal(isEligibleForReview([], []), false);
+  assert.equal(isEligibleForReview(["bug"], [{ labels: ["enhancement"] }]), false);
+});

--- a/scripts/pr-review/diff.mjs
+++ b/scripts/pr-review/diff.mjs
@@ -1,0 +1,44 @@
+// Parses a GitHub API unified-diff "patch" string into per-line info for
+// the new (RIGHT-side) file. Pure, no I/O — see build-review.test.mjs.
+
+/**
+ * @param {string} patch - the `patch` field GitHub's pulls.listFiles API
+ *   returns for one file (hunks only, no `--- a/`/`+++ b/` file headers).
+ * @returns {Map<number, string>} new-file line number -> line content, for
+ *   every line GitHub allows a RIGHT-side review comment on (context lines
+ *   and added lines). Deleted lines have no RIGHT-side line number and are
+ *   omitted.
+ */
+export function parsePatch(patch) {
+  const lines = new Map();
+  if (!patch) return lines;
+
+  let newLine = 0;
+  const rawLines = patch.split("\n");
+  for (let i = 0; i < rawLines.length; i++) {
+    const raw = rawLines[i];
+    if (raw.startsWith("@@")) {
+      const match = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (!match) continue;
+      newLine = Number(match[1]);
+      continue;
+    }
+    if (raw.startsWith("\\")) continue; // "\ No newline at end of file"
+    if (raw.startsWith("-")) continue; // old-file-only line, no RIGHT anchor
+    if (raw.startsWith("+")) {
+      lines.set(newLine, raw.slice(1));
+      newLine++;
+      continue;
+    }
+    // Only the final element of split() on a patch ending in "\n" is a bare
+    // "" — drop it. A blank *context* line is " " (leading space marker), so
+    // it falls through to the context branch and keeps newLine in sync; a
+    // stray mid-patch "" is likewise treated as blank context, never skipped
+    // (skipping without advancing newLine would desync every later anchor).
+    if (raw === "" && i === rawLines.length - 1) continue;
+    // context line: strip the diff's single leading space marker
+    lines.set(newLine, raw.slice(1));
+    newLine++;
+  }
+  return lines;
+}

--- a/scripts/pr-review/run.mjs
+++ b/scripts/pr-review/run.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+// Vendored verbatim from carpet-stain/dotfiles' scripts/pr-review/ (see
+// project-starter-template#60). Issue and ADR numbers referenced below
+// (#330, #458, #456, docs/adr/0025) are dotfiles' own — this repo doesn't
+// have matching ones, they're upstream provenance, not local pointers.
+//
+// DIY advisory PR reviewer (issue #330): calls a non-Anthropic model on the
+// PR diff and posts genuine per-line review comments — with real
+// `suggestion` blocks GitHub renders as one-click-applyable — via
+// pulls.createReview. Replaces anc95/ChatGPT-CodeReview, whose comments
+// batch per-file with no real suggestion anchoring (see #304's PR
+// discussion). Wired from ../../.github/workflows/pr-code-review.yml;
+// stays advisory-only per docs/adr/0025 — posts a COMMENT-event review,
+// never APPROVE/REQUEST_CHANGES, so it can't gate a merge on its own.
+//
+// Talks to the GitHub REST + GraphQL APIs and an OpenAI-compatible
+// chat-completions endpoint (OpenAI, or OpenRouter's free tier — set via
+// OPENAI_API_URL / OPENAI_MODEL) directly with the platform `fetch` (no
+// octokit/openai SDK, no third-party Action in the request path — the whole
+// point of #330 over the prior action). GraphQL (fetchPrContext) resolves
+// the PR's plan-conformance trigger + context (#458); REST handles the diff
+// and posting the review. All I/O lives here; the parsing/formatting logic
+// in diff.mjs and build-review.mjs is pure and unit-tested in isolation
+// (build-review.test.mjs) since this workflow can't be exercised end-to-end
+// outside a real PR run.
+
+import { parseFiles, buildPrompt, buildReviewComments, buildContext, isEligibleForReview, MAX_ISSUES } from "./build-review.mjs";
+
+const {
+  GITHUB_TOKEN,
+  OPENAI_API_KEY,
+  OPENAI_MODEL = "gpt-4o-mini",
+  GITHUB_REPOSITORY,
+  PR_NUMBER,
+  GITHUB_API_URL = "https://api.github.com",
+  GITHUB_GRAPHQL_URL = "https://api.github.com/graphql",
+  OPENAI_API_URL = "https://api.openai.com/v1/chat/completions",
+} = process.env;
+
+for (const [name, value] of Object.entries({
+  GITHUB_TOKEN,
+  OPENAI_API_KEY,
+  GITHUB_REPOSITORY,
+  PR_NUMBER,
+})) {
+  if (!value) {
+    console.error(`pr-review: missing required env var ${name}`);
+    process.exit(1);
+  }
+}
+
+const [owner, repo] = GITHUB_REPOSITORY.split("/");
+
+async function githubRequest(path, options = {}) {
+  const res = await fetch(`${GITHUB_API_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...options.headers,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${options.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+async function fetchPrFiles() {
+  const files = [];
+  for (let page = 1; ; page++) {
+    const batch = await githubRequest(`/repos/${owner}/${repo}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}`);
+    files.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return files;
+}
+
+async function githubGraphQL(query, variables) {
+  const res = await fetch(GITHUB_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub GraphQL request failed: ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  if (body.errors) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(body.errors)}`);
+  }
+  return body.data;
+}
+
+const PR_CONTEXT_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!, $maxIssues: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        title
+        body
+        labels(first: 20) { nodes { name } }
+        closingIssuesReferences(first: $maxIssues) {
+          nodes {
+            number
+            title
+            body
+            labels(first: 20) { nodes { name } }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// The PR + the issue(s) it closes, resolved via GitHub's own computed
+// closingIssuesReferences field (#458) — not a body-text regex, so a typo'd
+// closing keyword can't silently mis-scope either the review context or the
+// trigger below. Also decides whether to review at all: this repo's
+// plan-review gate consolidates the approved plan + acceptance criteria
+// into a plan-approved issue's body, which is exactly what a conformance
+// review needs, so a PR closing one auto-triggers; needs-review is the
+// on-demand opt-in for anything else (#456). Unlike the old diff-only
+// fallback, a fetch failure here means skip rather than guess — this call
+// also gates the OpenAI spend, so erring toward "don't run" beats erring
+// toward an unbounded review on every transient API error.
+async function fetchPrContext() {
+  const data = await githubGraphQL(PR_CONTEXT_QUERY, {
+    owner,
+    repo,
+    number: Number(PR_NUMBER),
+    maxIssues: MAX_ISSUES,
+  });
+  const pr = data.repository.pullRequest;
+  const labels = pr.labels.nodes.map((l) => l.name);
+  const issues = pr.closingIssuesReferences.nodes.map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    labels: issue.labels.nodes.map((l) => l.name),
+  }));
+  return { pr: { title: pr.title, body: pr.body }, issues, eligible: isEligibleForReview(labels, issues) };
+}
+
+// Structured Outputs schema: forces the model to return exactly this
+// shape instead of free text to re-parse (the acceptance criterion #330
+// leads with). `strict: true` makes the API itself reject a malformed
+// response rather than us discovering it at JSON.parse time.
+const FINDINGS_SCHEMA = {
+  name: "review_findings",
+  strict: true,
+  schema: {
+    type: "object",
+    properties: {
+      findings: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            file: { type: "string" },
+            line: { type: "integer" },
+            severity: { type: "string", enum: ["blocking", "recommended", "nit", "pre-existing"] },
+            comment: { type: "string" },
+            suggestion: { type: ["string", "null"] },
+          },
+          required: ["file", "line", "severity", "comment", "suggestion"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["findings"],
+    additionalProperties: false,
+  },
+};
+
+// The rubric, severity ladder, and anti-noise rules below are distilled from
+// established review guidance (Google eng-practices; Netlify "feedback
+// ladders"; Bosu/Greiler/Bird 2015, "Characteristics of Useful Code
+// Reviews") — the empirical finding being that a useful comment names a
+// concrete change, and questions/praise/nitpick-pile-ons are measured noise.
+const SYSTEM_PROMPT = `You are an independent code reviewer looking at a pull request diff — a
+different model than the one that wrote the change, so bring genuinely
+independent eyes. Each file is shown as its changed lines, prefixed with the
+exact line number in the new version of the file; only those numbered lines
+can be commented on.
+
+When an "## Intent" section precedes the changed lines, it states what the
+change should accomplish (from the PR description and any issue it closes —
+for a reviewed issue, that's the approved plan and its acceptance criteria).
+Use it as the spec to check the diff against: does the change actually
+achieve it, stay in scope, and satisfy every acceptance criterion listed?
+Treat it as the goal to verify, never as proof the work is done — a diff
+that diverges from the stated approach, or leaves a listed criterion unmet,
+is a finding.
+
+Look for problems in this order, highest value first — spend your attention
+at the top of the list, not the bottom:
+1. Correctness: wrong logic, broken behavior, off-by-one, misuse of an API.
+2. Edge cases and failure modes: unhandled errors, boundary/empty input,
+   race conditions, resource leaks.
+3. Security: injection, path traversal, unsafe deserialization, secrets in
+   code.
+4. Design fit: does the change belong here and match the surrounding code;
+   flag over-engineering and speculative generality.
+5. Tests: missing coverage for a new path; a test that wouldn't fail if the
+   code broke.
+6. Clarity: naming that misleads, needless complexity, a comment that should
+   explain why.
+Do not report formatting, import order, or anything a linter/formatter
+already catches — that is out of scope for this review.
+
+Classify each finding with a "severity", most severe first:
+- "blocking": a defect or design flaw in the CHANGED code; the PR should not
+  merge until it is addressed.
+- "recommended": a real improvement the author should make, but that need
+  not block the merge.
+- "nit": minor, optional polish — take it or leave it.
+- "pre-existing": a real issue in code this diff did not introduce; flagged
+  for awareness only, never blocks this PR.
+
+Rules that keep the review signal high:
+- Every finding must name a CONCRETE change. If you cannot say what to do
+  differently, do not raise it. Never emit questions-to-understand, praise,
+  or vague observations.
+- Every finding's comment states WHY in one or two sentences — the failure
+  it prevents or the principle it serves.
+- If the same issue recurs, emit ONE finding, note it "applies throughout",
+  and do not repeat it per occurrence.
+- Keep nits few; never let them crowd out a blocking or recommended finding.
+- Only when the fix is a mechanical, single-line replacement, put the exact
+  replacement text for that one line (no line-number prefix) in
+  "suggestion"; otherwise set "suggestion" to null.
+
+Say nothing about lines that are fine — return an empty findings array if the
+diff has no real issues. Do not invent a file or line number that wasn't
+shown to you.`;
+
+async function callOpenAI(prompt) {
+  const payload = {
+    model: OPENAI_MODEL,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: prompt },
+    ],
+    response_format: { type: "json_schema", json_schema: FINDINGS_SCHEMA },
+  };
+  // OpenRouter serves a model across several provider endpoints, not all of
+  // which enforce a json_schema; require_parameters makes it route only to one
+  // that does, so we don't silently get unstructured output. OpenAI rejects
+  // unknown body fields, so send it only when the endpoint is OpenRouter.
+  if (OPENAI_API_URL.includes("openrouter.ai")) {
+    payload.provider = { require_parameters: true };
+  }
+  const res = await fetch(OPENAI_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenAI API request failed: ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  const content = body.choices?.[0]?.message?.content;
+  if (!content) throw new Error("OpenAI response had no message content");
+  return JSON.parse(content).findings ?? [];
+}
+
+async function postReview(comments, dropped) {
+  const clean = comments.length === 0 && dropped === 0;
+  const summary = clean
+    ? `Advisory review (non-Anthropic model, different eyes than the one that wrote the change) — no issues found. LGTM. Advisory only — a human approves the merge.`
+    : `Advisory review (non-Anthropic model, different eyes than the one that wrote the change) — ${comments.length} finding` +
+      `${comments.length === 1 ? "" : "s"}` +
+      (dropped ? `, ${dropped} dropped (referenced a file/line outside the diff)` : "") +
+      `. Advisory only — a human approves the merge.`;
+
+  // Always a COMMENT-event review, even with zero findings — never
+  // APPROVE/REQUEST_CHANGES (docs/adr/0025): an approval could satisfy a
+  // future required-reviews gate with no human involved, and "changes
+  // requested" can itself block merging on some branch-protection setups,
+  // reintroducing the "LLM outage blocks every PR" failure this design
+  // rejected. Posting even when clean is what makes the review visible in
+  // the PR's own Reviewers panel instead of only in Action logs.
+  await githubRequest(`/repos/${owner}/${repo}/pulls/${PR_NUMBER}/reviews`, {
+    method: "POST",
+    body: JSON.stringify({ event: "COMMENT", body: summary, comments }),
+  });
+}
+
+async function main() {
+  let pr, issues, eligible;
+  try {
+    ({ pr, issues, eligible } = await fetchPrContext());
+  } catch (err) {
+    console.log(`::warning title=PR advisory review::skipped, trigger check failed: ${err.message}`);
+    return;
+  }
+  if (!eligible) {
+    console.log("pr-review: not needs-review-labeled and closes no plan-approved issue — skipping.");
+    return;
+  }
+
+  const rawFiles = await fetchPrFiles();
+  const parsedFiles = parseFiles(rawFiles);
+  if (parsedFiles.length === 0) {
+    console.log("pr-review: no reviewable (text, non-binary) file changes — skipping.");
+    return;
+  }
+
+  const context = buildContext(pr, issues);
+  const diff = buildPrompt(parsedFiles);
+  const prompt = context ? `${context}\n\n---\n\n## Changed lines to review\n\n${diff}` : diff;
+  const findings = await callOpenAI(prompt);
+  const { comments, dropped } = buildReviewComments(parsedFiles, findings);
+
+  await postReview(comments, dropped);
+  console.log(
+    comments.length === 0 && dropped === 0
+      ? "pr-review: no findings — posted LGTM."
+      : `pr-review: posted ${comments.length} comment(s), ${dropped} dropped.`,
+  );
+}
+
+main().catch((err) => {
+  // Advisory reviewer: a transient OpenAI/GitHub outage or rate-limit must
+  // never fail the check (docs/adr/0025 — human approval is the gate and
+  // this job is deliberately not a required check). Log the full error for
+  // diagnosis, surface a warning annotation so a real misconfig (bad key,
+  // missing perms) stays visible in the PR checks UI, then exit 0 so the run
+  // stays green. Wiring errors in our own env are still caught loud above
+  // (missing required env var -> exit 1) before any of this runs.
+  console.error(err);
+  console.log(`::warning title=PR advisory review::skipped after error: ${err.message}`);
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

Scaffolds `project-starter-template`'s `git-flow` governance base via the retrofit-merge approach (`retrofit-governance.sh`'s strategy, generated + merged by hand since the script itself isn't vendored into this repo): PR guards, ADR guard, base lint CI, lefthook/justfile composition, ADR scaffolding, issue/PR templates. Seats the three checks this repo's `protect main` ruleset already requires (`adr guard`, `single commit`, `conventional commit`) — previously nothing emitted them, so every PR was unmergeable.

`include_release_automation=false` — this repo is consumed as a submodule tracking `main`, no SemVer releases yet (per the issue's own recommendation). Flip the copier answer later if that changes.

`AGENTS.md` added (via `compose-agents`), declaring itself authoritative over the generic agent-config rules for this repo's workflow. `README.md` rewritten to describe the repo's real purpose instead of the template stub.

## Deviations from the issue

None from the scope — infra#177 already did repo creation + ruleset + labels, so per the template's own bootstrap runbook, steps 3–4 (labels, branch protection) are skipped; only step 2 (scaffold) applied here.

## Verification

- Confirmed the bootstrap self-satisfy question the issue raised: `pr-guards.yml`/`adr-guard.yml` run against this same PR (reported "skipping" while draft, gated on `draft == false` — expected).
- `just lint` (lefthook) green locally.
- `AGENTS.md` present, declares precedence over generic rules.
- `README.md` reflects this repo's actual purpose (submodule consumed by `carpet-stain/dotfiles`), not the template stub.

Closes #3