### PR TITLE
refactor(claude): import the stable subset from carpet-stain/dotfiles with history

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -8,3 +8,10 @@ config:
   # Generated docs and ADRs may open with a badge line or front matter before
   # the H1 — don't force the first line to be a top-level heading.
   MD041: false
+  # rules/*.md deliberately open with a blockquote-styled GATE/LOCAL-WINS/
+  # COMPOSE meta-header (stacked blockquote paragraphs, separated by blank
+  # lines) before the file's real H1 — not a mistake to flag.
+  MD028: false
+  # <placeholder> markers (<scopes>, <version-scheme>, etc.) in rules/ are
+  # literal template syntax, not real HTML.
+  MD033: false

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ Claude Code and emitted in a form no model is locked out of.
 `rules/` groups files by how broadly they apply — the directory name is the scope, nothing to
 cross-reference:
 
-| Directory             | File                        | Applies to                             | Loading                                                              |
-| ---------------------- | --------------------------- | --------------------------------------- | ---------------------------------------------------------------------- |
-| `rules/universal/`     | `design-principles.md`      | How code/tools are shaped              | Always applies                                                       |
-|                         | `engineering-practices.md`  | How work gets done (testing, security) | Always applies                                                       |
-|                         | `documentation.md`          | Documentation ownership & currency     | Always applies                                                       |
-|                         | `ai-collaboration.md`       | How the agent operates                 | Always applies                                                       |
-|                         | `communication.md`          | What gets said/written                 | Always applies                                                       |
-| `rules/domain/`        | `architecture.md`           | Building a layered application         | Self-gates on being a layered app                                    |
-| `rules/tools/`         | `git.md`                    | Any git repo, any host                 | Always applies (trivial gate)                                        |
-|                         | `go.md`                     | Go repos only                          | Native `paths:` frontmatter — loads only on `go.mod`/`*.go`          |
-|                         | `python.md`                 | Python repos only                      | Native `paths:` frontmatter — loads only on `pyproject.toml`/`*.py`  |
-|                         | `terraform.md`              | Terraform/OpenTofu repos only          | Native `paths:` frontmatter — loads only on `*.tf`/`*.tofu`/etc.     |
-| `rules/platform/`      | `github.md`                 | GitHub-hosted repos only               | Self-gates on github.com origin                                      |
-| _(a consuming repo)_   | a private platform file, local-only rules, `AGENTS.md` + `docs/` | One repo only | The consuming repo's own local files, layered alongside this tree |
+| Directory            | File                                                             | Applies to                             | Loading                                                             |
+| -------------------- | ---------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
+| `rules/universal/`   | `design-principles.md`                                           | How code/tools are shaped              | Always applies                                                      |
+|                      | `engineering-practices.md`                                       | How work gets done (testing, security) | Always applies                                                      |
+|                      | `documentation.md`                                               | Documentation ownership & currency     | Always applies                                                      |
+|                      | `ai-collaboration.md`                                            | How the agent operates                 | Always applies                                                      |
+|                      | `communication.md`                                               | What gets said/written                 | Always applies                                                      |
+| `rules/domain/`      | `architecture.md`                                                | Building a layered application         | Self-gates on being a layered app                                   |
+| `rules/tools/`       | `git.md`                                                         | Any git repo, any host                 | Always applies (trivial gate)                                       |
+|                      | `go.md`                                                          | Go repos only                          | Native `paths:` frontmatter — loads only on `go.mod`/`*.go`         |
+|                      | `python.md`                                                      | Python repos only                      | Native `paths:` frontmatter — loads only on `pyproject.toml`/`*.py` |
+|                      | `terraform.md`                                                   | Terraform/OpenTofu repos only          | Native `paths:` frontmatter — loads only on `*.tf`/`*.tofu`/etc.    |
+| `rules/platform/`    | `github.md`                                                      | GitHub-hosted repos only               | Self-gates on github.com origin                                     |
+| _(a consuming repo)_ | a private platform file, local-only rules, `AGENTS.md` + `docs/` | One repo only                          | The consuming repo's own local files, layered alongside this tree   |
 
 Roughly ordered by breadth: universal (every project) → domain (a class of codebase, e.g. a
 layered application) → tools (git/language) → platform (host) → repo (whichever repo consumes

--- a/README.md
+++ b/README.md
@@ -3,15 +3,360 @@
 Shared AI-agent definitions — personas, universal rules, skills, the memory contract.
 Provider-neutral markdown, consumed per-project.
 
+Reusable agent instructions for [Claude Code](https://claude.ai/code), designed so **abstract
+engineering philosophy is written once and inherited by every project**, while language-,
+platform-, and repo-specific detail stays scoped to where it actually applies.
+
 ## Use
 
-Consumed as a submodule by downstream repos (e.g. `carpet-stain/dotfiles`), not run
-standalone.
+Consumed as a submodule by downstream repos (e.g. `carpet-stain/dotfiles`), not run standalone.
+A consuming repo's deploy step symlinks `rules/`, `agents/`, and `skills/` into Claude Code's
+`~/.claude/` (see that repo's own deploy docs for the exact layering, since a repo may keep a few
+local-only files alongside what this repo provides).
+
+## Why this exists
+
+A single monolithic `CLAUDE.md`/`AGENTS.md` per repo mixes three incompatible things:
+
+1. **Universal philosophy** — how code should be designed, tested, and shipped. True everywhere.
+2. **Language/platform conventions** — Go idioms, a hosting platform's mechanics. True for _some_ repos.
+3. **Repo-specific facts** — commands, paths, branch names. True for _one_ repo.
+
+Mixing them blocks reuse (you can't lift the philosophy into another repo without dragging repo
+facts along) and injects **wrong context** into the agent (Go rules in a Python repo, one
+platform's commands in an unrelated repo). This repo keeps them apart.
+
+## Claude Code authors it; `AGENTS.md` is what any agent reads
+
+This machinery is **Claude Code-specific**: the `~/.claude/rules/` tree, `paths:` gating, the
+GATE/LOCAL-WINS/COMPOSE blocks the agent evaluates, the skills, the subagents. No other tool
+reads `~/.claude/rules/` or honors that structure — it's built on how Claude Code discovers and
+loads rules.
+
+What it _produces per repo_ is deliberately not. `compose-agents` instantiates these Claude Code
+rules into a repo's **`AGENTS.md`** — the emerging cross-tool convention other agents (Cursor,
+Codex, and the rest) read — as a self-contained doc with **zero dependency on this repo behind
+it**. That's the [self-containment](#compose-and-why-the-duplication-is-deliberate) COMPOSE
+already demands, pushed one step further: the local doc must be correct not just for a
+contributor without these global files, but for a _different model entirely_.
+
+The bridge is a symlink. Claude Code looks for `CLAUDE.md`; the vendor-neutral file is
+`AGENTS.md`. Each composed repo carries a gitignored **`CLAUDE.md → AGENTS.md`** symlink, so
+Claude Code reads the exact file every other agent reads as `AGENTS.md` — one source of truth,
+two names. `compose-agents` proposes this symlink (its Step 7). So: **Claude Code-specific
+authoring here → vendor-neutral consumption per repo.** The philosophy is written once against
+Claude Code and emitted in a form no model is locked out of.
+
+## How the files are organized
+
+`rules/` groups files by how broadly they apply — the directory name is the scope, nothing to
+cross-reference:
+
+| Directory             | File                        | Applies to                             | Loading                                                              |
+| ---------------------- | --------------------------- | --------------------------------------- | ---------------------------------------------------------------------- |
+| `rules/universal/`     | `design-principles.md`      | How code/tools are shaped              | Always applies                                                       |
+|                         | `engineering-practices.md`  | How work gets done (testing, security) | Always applies                                                       |
+|                         | `documentation.md`          | Documentation ownership & currency     | Always applies                                                       |
+|                         | `ai-collaboration.md`       | How the agent operates                 | Always applies                                                       |
+|                         | `communication.md`          | What gets said/written                 | Always applies                                                       |
+| `rules/domain/`        | `architecture.md`           | Building a layered application         | Self-gates on being a layered app                                    |
+| `rules/tools/`         | `git.md`                    | Any git repo, any host                 | Always applies (trivial gate)                                        |
+|                         | `go.md`                     | Go repos only                          | Native `paths:` frontmatter — loads only on `go.mod`/`*.go`          |
+|                         | `python.md`                 | Python repos only                      | Native `paths:` frontmatter — loads only on `pyproject.toml`/`*.py`  |
+|                         | `terraform.md`              | Terraform/OpenTofu repos only          | Native `paths:` frontmatter — loads only on `*.tf`/`*.tofu`/etc.     |
+| `rules/platform/`      | `github.md`                 | GitHub-hosted repos only               | Self-gates on github.com origin                                      |
+| _(a consuming repo)_   | a private platform file, local-only rules, `AGENTS.md` + `docs/` | One repo only | The consuming repo's own local files, layered alongside this tree |
+
+Roughly ordered by breadth: universal (every project) → domain (a class of codebase, e.g. a
+layered application) → tools (git/language) → platform (host) → repo (whichever repo consumes
+this one). A specificity gradient, not a numbered system: every file's gate is evaluated
+independently, so a file that documents itself as "assuming X" (`github.md` assumes `git.md`) is
+a trusted relationship, not a mechanically checked one.
+
+There is no loader file. Claude Code auto-discovers and loads `~/.claude/rules/` recursively in
+every project. Drop a file into the right directory and it loads — nothing to wire.
+
+**Why split at all, rather than one file?** Two reasons a monolith can't give. Topical files keep
+each one focused enough that the removal test (below) stays usable — easy to ask "does
+`design-principles.md` earn every line," hard to ask it of a file that's also about testing, AI
+conduct, and prose. And separating `git.md` (branching philosophy true on any host) from `github.md`
+(`gh`, Actions, squash-merge behavior specific to one host) lets a GitLab repo reuse the same
+`git.md` baseline with a `gitlab.md` beside it.
+
+## The model: load-all, then self-gate — except where a native gate exists
+
+Most files load in **every** project; scope is enforced _after_ loading, by named blocks at the top
+of each file the agent evaluates against the current repo — **GATE** (when the file applies),
+**LOCAL-WINS** (a repo's own doc beats it on overlap), and, for tools/platform files, **COMPOSE**
+(how to instantiate it). A file carries only the blocks it needs. The GATE conditions:
+
+- `universal/` → apply always (no gate).
+- `domain/architecture.md` → only when the repo builds a layered application; a soft prose GATE like
+  `github.md`, since there's no crisp path signal for "is this a layered app."
+- `git.md` → if this repo uses git (nearly always — a rare-exception gate, not a real filter).
+- `github.md` → only if the repo's origin is GitHub; otherwise ignored.
+- a private platform file → only if that platform's tooling is present; otherwise ignored
+  (emphatically — its commands are _wrong_ elsewhere, not merely unnecessary). Distinct platforms are
+  mutually exclusive per repo, each gating on its own tooling.
+
+The language files (`go.md`, `python.md`, `terraform.md`) are the exception: they use Claude Code's
+native `paths:` frontmatter instead of a prose guard, because "is this a `.go`/`go.mod` (or
+`.py`/`pyproject.toml`, or `.tf`) file" is a crisp per-file signal a glob expresses directly —
+unlike GitHub-origin or platform-tooling checks, which have no path to hook into.
+
+This is a **blacklist** (load everything, exclude what doesn't fit), not a whitelist (opt-in per
+repo). Worth it because only a few broad files match most work, so loading them all is a small,
+fixed cost with **zero per-repo wiring**. If many niche files accumulate later, revisit —
+whitelist scales better then. Two honest caveats:
+
+- **Soft gating.** For prose-gated files, exclusion works because the model honors the GATE text, not
+  because the file is structurally absent — reliable for crisp guards ("not GitHub → ignore"), but
+  still soft, and the file's bytes load either way. `go.md`'s `paths:` gate is the sturdier kind:
+  structurally absent until Claude reads a Go file, then loaded for that session. Prefer a path gate
+  wherever one fits; not every gate can be one.
+- **Cost is in length, not count.** Loading a handful of files every session is cheap; a _long_ file
+  is not — verbosity itself reduces adherence, so the files stay few and short. See
+  [Why the rule files are terse](#why-the-rule-files-are-terse).
+
+## Local-wins precedence
+
+When an applied file overlaps a repo's own docs, **the repo wins**. Enforced redundantly so no
+single soft instruction is load-bearing:
+
+1. Each file's LOCAL-WINS block says "if the repo has its own doc, prefer it; treat this as baseline."
+2. The repo's committed `AGENTS.md` independently claims authority for its `docs/`.
+3. (For composed repos) the COMPOSE step writes that precedence line into the repo.
+4. Natively, Claude Code loads user-level rules _before_ a repo's own `CLAUDE.md`/`.claude/rules/`,
+   so the repo's files come later and carry higher priority — load-order backing for local-wins.
+   Still context, not hard enforcement (only a hook enforces), but the one reinforcement that isn't
+   soft prose.
+
+The `universal/` files are the exception: a repo never _overrides_ them — a repo's `DESIGN.md`
+_illustrates_ how the principles are realized there. Illustrate, don't replace.
+
+## COMPOSE, and why the duplication is deliberate
+
+`git.md` and a platform file are **templates** with literal `<placeholders>` (scopes, branch names);
+`go.md` has softer abstractions ("your linter"). When a repo _lacks_ a concrete doc for one, the
+file's COMPOSE block tells the agent how to distill a repo-specific doc (e.g. `docs/CODING.md`, an
+`AGENTS.md` section) by filling in the real nouns, then wire the precedence line. Default is
+**propose-don't-create** — the agent suggests and waits before writing committed files. `github.md`
+has no `<placeholders>` and no COMPOSE block (`git.md` owns everything composable); the `universal/`
+files have none either — a standard is applied, not instantiated.
+
+The result **duplicates**: a composed repo's `AGENTS.md` is a _full instantiation_ of the abstract —
+it restates the structure with the repo's nouns, so the abstract (always loaded) and the local
+restatement sit in context together. That's deliberate, for two reasons:
+
+- **Self-containment.** The local doc must be correct for a reader with none of these global files —
+  another contributor, CI, an agent on a different machine. A public repo's `AGENTS.md` can't assume
+  this repo is loaded behind it, so it restates the generic structure rather than pointing at a file
+  the reader may not have.
+- **Uncomposed repos.** The abstract earns its keep in repos that have _no_ `AGENTS.md` yet — there
+  it's the whole guidance. Composed repos tolerate the overlap; that's the price of the abstract being
+  universally present.
+
+Duplication's only real danger is divergence — two statements of the branch model drifting apart. The
+guard is _direction_: the abstract is the **source**, the local doc is **derived from it** by COMPOSE,
+and the abstract goes **inert** for that repo afterward (it was distilled _from_ that repo and must
+not be fed back). Change a convention in one place — the abstract — and re-compose; never hand-edit
+the instantiated structure expecting it to flow back. One source, one derived artifact.
+
+## Subagents (`agents/`)
+
+Alongside the always-loaded `rules/`, `agents/` holds Claude Code **subagents** — specialized
+assistants the main agent delegates to for a bounded job, each with its own context, system prompt,
+tools, and model. A subagent is **not** always-on context — it loads only when delegated to, so it
+costs nothing until used.
+
+- **`plan-reviewer`** — an adversarial, read-only design reviewer: a fresh isolated context critiques
+  a plan, design, or architecture _before_ it's built and returns a ranked critique (gaps, risks,
+  unstated assumptions, boundary problems, simpler alternatives). Repo-agnostic — reads the repo's
+  conventions at runtime — and read-only by structural guarantee (no Write/Edit in its tools, like
+  `audit-rules`). Delegate before committing to a non-trivial plan, or by name.
+
+A consuming repo may keep additional subagents of its own alongside this tree (a project-manager /
+backlog specialist with persistent memory, for instance) — those live in the consuming repo, not
+here, when they carry repo-specific memory or identity that shouldn't be shared across every
+consumer.
+
+## Skills (`skills/`)
+
+A Skill is on-demand, not always-on: Claude Code invokes it by name (`/skill-name`) or
+auto-invokes it when its `description` matches the request, and it costs nothing outside that.
+That's the deciding difference from a subagent — a subagent earns its place only when persistent
+memory, repeated delegation, _and_ context isolation all apply together, with one exception: an
+adversarial reviewer (`plan-reviewer`) earns it on context isolation alone, because a skill runs
+in the same context that produced the thing and so can't bring fresh eyes to it. A one-shot
+analysis with neither persistent memory nor that isolation-is-the-point constraint is a skill,
+not a subagent. Each skill's `SKILL.md` lives at `skills/<name>/SKILL.md`, discovered recursively,
+no per-skill wiring. Skills are repo-agnostic and don't GATE the way rules do — a skill either
+fires on request or it doesn't, there's nothing to self-gate against a repo's shape.
+
+- **`audit-rules`** — reads `~/.claude/rules/` and reports contradictions (two directives that
+  disagree) and sprawl (files over ~200 lines or spanning more than one topic). Propose-don't-apply,
+  enforced structurally: it has no Write/Edit access, so it can only report findings, never act on
+  them.
+- **`compose-agents`** — the opposite direction: drafts or updates a repo's `AGENTS.md` by
+  instantiating each applicable rule file's COMPOSE block with facts detected from the repo (branch
+  model, version scheme, scopes, pre-commit tooling). Propose-don't-create: it presents a full draft
+  or diff in chat and waits for approval before anything is written.
+- **`audit-memory`** — read-only audit of a project-manager subagent's MCP knowledge-graph memory
+  for staleness against live GitHub state, one-home duplication, and broken graph structure. The
+  detection backstop to that subagent's own write-time contract, wherever it's defined.
+- **`grilling`** — extracts decisions one at a time before committing to a plan, instead of guessing
+  a batch of assumptions, for genuinely undecided scope.
+- **`groom-backlog`** — the periodic backlog-sweep procedure: untriaged issues, priority re-weigh,
+  dedup, weak-issue tightening, label drift, epic-child verification.
+- **`implement-issue`** — a worker-session ritual for implementing a single shaped GitHub issue end
+  to end, pointing at the consuming repo's own git workflow for branch/PR mechanics rather than
+  restating them.
+
+**Authoring convention — keep a `SKILL.md` lean.** Intent, triggers, and a map of what's
+available belong in the entry file; target one screen, with ~500 lines the ceiling, not a goal.
+Depth that only some runs need — long checklists, worked examples, per-case detail — lives in
+`resources/*.md` beside it, loaded on demand. A skill's cost is the length it pulls into context,
+not the count of skills, so a skill that outgrows a screen offloads depth to resource files
+instead of inlining it.
+
+**When something earns being a skill — three gates, all present.** Shape aside, a lesson is
+skill-worthy only when: a check actually passed (a green test, a clean exit, a reproduced repro —
+"seemed to work" doesn't count); the specific failure it avoids or diagnoses is named; and at
+least one dead-end is recorded — an approach tried and ruled out, with the reason. Miss one and
+it's a memory note (for agents that keep memory) or nothing, not a skill.
+
+**An MCP must earn its context tax.** Tool schemas load into every session, so a default MCP
+server taxes every session's context whether it's used or not. Default to a skill wrapping a CLI
+or REST call; reach for an MCP only when it needs what a CLI-in-a-skill can't give — interactive
+session state, streaming, an auth handshake, or structured browsing.
+
+## Lifecycle: running the skills over a repo's life
+
+`compose-agents` and `audit-rules`, plus Claude Code's built-in `/init` and `/doctor`, all touch
+a repo's `AGENTS.md` — but they were built separately, so the order that works depends on where
+the repo starts.
+
+**Fresh repo (no `AGENTS.md`/`CLAUDE.md`).**
+
+1. **`compose-agents`** (Draft mode) — drafts `AGENTS.md`: instantiated rule sections (each with a
+   `> Concrete realization of …` lineage line) plus `<!-- TODO -->` skeletons for the
+   codebase-domain sections. Approve, it writes.
+2. **Fill the TODO sections** — have the main agent analyze the codebase into them. _Not_
+   `/init`: it writes `CLAUDE.md`, not `AGENTS.md` (see the friction note), so here it drafts the
+   wrong file.
+3. **`audit-rules`** — QA the result: `AGENTS.md`↔`README` replication, restated enforcement,
+   sprawl.
+4. **Add the gitignored `CLAUDE.md → AGENTS.md` symlink** last, as final wiring.
+
+**Repo whose doc contradicts a rule.** A contradiction is _allowed_ — under LOCAL-WINS the repo
+wins — so the job is to separate a deliberate override from accidental drift. `compose-agents`
+(Update mode, or Migrate mode for a real `CLAUDE.md`) reads the doc, and where a hand-authored
+section contradicts a rule it _surfaces the choice_ rather than overwriting: adopt the rule's
+semantics, or keep the override and record it with a marker —
+`> Overrides **<rule>.md** § … — reason: …`. `audit-rules` reads that same marker: a marked
+section is a settled departure it skips; an _unmarked_ contradiction is what it flags, proposing
+either adoption or the marker. Deliberate overrides go quiet once marked; only accidental drift
+keeps surfacing.
+
+**Repo with an `AGENTS.md` silent on the rules' topics.** `compose-agents` Update mode _augments_
+it: for every rule that gates on for the repo but has no section in the doc, it proposes adding
+the instantiation, leaving existing prose untouched. A doc that predates the rules gets offered
+exactly what it's missing instead of being left alone.
+
+**Two frictions with the built-ins:**
+
+- **`/init` targets `CLAUDE.md`.** This setup is `AGENTS.md`-canonical (`CLAUDE.md` is a symlink
+  to it), so running `/init` blind produces a second, competing file. Use it only if you redirect
+  its output into `AGENTS.md`, or skip it and let the main agent fill the TODO sections.
+- **`/doctor` trims files over 200 lines.** `AGENTS.md` has a deliberately higher threshold
+  (soft-warn ~250, firm-flag ~300 — see [Why the rule files are
+  terse](#why-the-rule-files-are-terse)), so don't let `/doctor` cut a legitimately long one.
+  It's install-health, not part of this lifecycle.
+
+## Private files (work/internal platform files)
+
+Some platform files describe **internal or employer-owned tooling** (hostnames, CLIs, build systems)
+that must **never** land in a public repo. A consuming repo keeps these in one gitignored directory
+of its own — conventionally `rules/platform/private/` alongside wherever it layers this tree — so a
+new one is safe **by default**: dropping a file in there is enough, with no per-file `.gitignore`
+edit to remember and get wrong.
+
+1. **Write the file** with its own GATE and LOCAL-WINS blocks, exactly like a committed platform file.
+2. **Nothing else.** The directory is gitignored as a whole in the consuming repo, so the file can't
+   be committed by accident.
+
+**Why a whole ignored directory, not a per-file ignore line:** naming each private file in
+`.gitignore` means one forgotten line leaks internal tooling into a public repo — the exact disaster
+this mechanism prevents — and it spells the private file's name out in the public `.gitignore`
+besides. A directory ignored wholesale is safe the instant a file lands in it, and names nothing.
+
+## Authoring rules for these files
+
+- **`universal/`, `domain/`, and `tools/` must contain no repo-specific nouns** — no paths, branch
+  names, service names. `domain/` is philosophy like `universal/` (illustrated, never overridden, no
+  COMPOSE); `tools/` may name Go/git tools and idioms; a `platform/` file may name that platform's
+  tools but keeps repo values as `<placeholders>`.
+- **References are one-directional**: a consuming repo may point at a file here; a file here must
+  never point at a specific consuming repo. A `platform/` file may point at its `tools/` baseline
+  (`github.md` → `git.md`).
+- **Never commit an internal/work platform file here** — that's always a consuming repo's own
+  [private file](#private-files-workinternal-platform-files).
+
+## Why the rule files are terse
+
+The `rules/` files are directives, not essays. They load into **every** session, and Claude Code's own
+guidance is blunt: files over ~200 lines cost context and _reduce_ adherence — the more concise the
+instruction, the more reliably it's followed. So the files hold themselves to `communication.md`'s own
+standard (terse, concrete, lead with the point) instead of exempting themselves from it.
+
+The split that keeps them lean:
+
+- **Directive vs. rationale.** The always-loaded file carries the _what_. The _why_ lives here in the
+  README (which loads _never_) when a reader would need it, or is cut entirely when it's generic
+  engineering knowledge the model already has ("write the minimum code" doesn't need three sentences
+  defending it). Non-obvious _why_ that changes behavior stays inline (e.g. force-push aborts if the
+  remote moved).
+- **No restatement.** A closing "Before Finishing" checklist that re-lists the file's own principles
+  is pure duplication; it's compressed to a handful of cross-cutting checks in `ai-collaboration.md`,
+  not repeated per file.
+
+**`AGENTS.md` gets a different, higher threshold.** It's not a rules file — it's the composed
+per-repo guide, legitimately carrying domain sections (what-this-is, structure, verification) none
+of the files above have, so the ~200 cap would false-positive constantly. Its own signal: soft-warn
+past ~250 lines, firmly flag past ~300. Past that point the usual cause is the same sprawl the rules
+files fight — restated enforcement or unpruned topic overlap — so `audit-rules` treats a long
+`AGENTS.md` as a symptom pointing at those checks, not a bare "too long."
+
+## Maintenance discipline (the removal test)
+
+These files should grow the same way any codebase should: additions earn their place, and nothing sits
+there just because it seemed like a good idea once.
+
+- **Add a rule only after it would have prevented an actual mistake** — not because it sounds reasonable
+  in the abstract.
+- **Remove a rule once it's being followed without being told** — a convention that's now just how
+  things are done doesn't need to keep paying rent in every session's context.
+- **Audit periodically for contradictions** across these files and against a consuming repo's own
+  docs; two rules that disagree mean the model picks one arbitrarily. The `audit-rules` skill
+  automates finding these (and length/topic sprawl) — it doesn't replace the judgment calls below,
+  only the sweep.
+- **Longer files weaken adherence** — if a file is growing, look for what it's earned the right to keep;
+  if it's growing because it covers more than one topic, split it. The same test applies to this
+  README: rationale lives here, but it earns its place too.
+
+## Verifying it works
+
+Run `/memory` in a fresh session inside any repo that consumes this tree — it lists every loaded
+`CLAUDE.md` and rules file, so you can confirm the `universal/` files and the applicable
+`tools/`/`platform/` files loaded from `~/.claude/rules/`. Then ask the agent whether each file's
+GATE fired correctly and whether local docs win on overlap. For a precise trace of which files
+loaded, when, and why — the definitive check that `go.md`'s `paths:` gate fires only on Go
+files — enable Claude Code's `InstructionsLoaded` hook, which logs exactly that. The decisive
+negative test is a repo on none of the gated platforms/languages — only the `universal/` files
+should apply.
 
 ## Contributing
 
 The contributor guide — workflow, commit rules, tooling, credentials — lives in
-`AGENTS.md` (composed from your agent-config rules; generate it if it isn't
-present yet). Architecture decisions live in
-[`docs/adr/`](docs/adr/README.md). This README is the human front door and
-points at those homes rather than restating them.
+`AGENTS.md`. Architecture decisions live in [`docs/adr/`](docs/adr/README.md). This README is the
+human front door and points at those homes rather than restating them.

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -1,0 +1,80 @@
+---
+name: plan-reviewer
+description: >-
+  Adversarial, read-only reviewer for a proposed plan, design, or architecture — before it's
+  built. Delegate to get a fresh, isolated critique of an approach the main agent or the user
+  just produced: gaps, unstated assumptions, risks and failure modes, missing considerations,
+  scope creep, and simpler alternatives. Use proactively before committing to any non-trivial
+  plan, design, or refactor. Not for reviewing finished code diffs (that's `/code-review`), and
+  it never writes code or files — it only critiques.
+tools: Read, Grep, Glob
+model: claude-opus-4-8
+color: red
+---
+
+# Plan Reviewer
+
+You are a senior engineer running an adversarial design review. You critique a plan, design, or
+proposed architecture that someone else — the main agent or the user — just produced, in a fresh
+context that did not write it. That independence is the whole point: you bring eyes the author
+can't, catching what reads as obvious-in-hindsight only from outside.
+
+You are **read-only**. You never write or edit code, never implement, never open a PR. Your one
+artifact is the critique. Write/Edit aren't in your tool surface — treat that as a structural
+guarantee, not a reminder.
+
+## Ground yourself before critiquing
+
+A review that ignores how this repo actually works is noise. Before judging a plan:
+
+- Read the repo's own conventions — `AGENTS.md`, the relevant `docs/` and ADRs, and the specific
+  files the plan touches. A plan that contradicts a recorded decision (an ADR, a stated
+  constraint) is a finding; one that follows it is not yours to relitigate.
+- Verify the plan's claims against the real code, not its description of the code. If it says "X
+  already handles this," open X and check. Assume the plan is wrong until the repo shows it right.
+
+Repo-agnostic: read the conventions here at runtime; never assume another repo's.
+
+## What to look for
+
+Rank by how much each would hurt if it shipped:
+
+- **Gaps** — a step the plan needs but doesn't name; a case it doesn't handle (errors, empty
+  input, concurrency, the can't-happen-but-does).
+- **Unstated assumptions** — a claim the plan rests on that isn't established. Name it, and say
+  what breaks if it's false.
+- **Risk & failure modes** — what goes wrong at runtime, on rollback, under load, on a second
+  run; what's expensive to reverse.
+- **Missing considerations** — testing, security, migration/rollback, observability, the next
+  reader — whichever the plan should have addressed and didn't.
+- **Boundary & ownership** — logic in the wrong layer, a leaked transport shape, an invariant far
+  from its model, an abstraction with a single call site. Judge against this repo's architecture,
+  not a generic ideal.
+- **Complexity that isn't paying for itself** — speculative flags, configurability nobody asked
+  for, scope creep past the stated goal. The simplest plan that solves the actual problem wins.
+- **A simpler alternative** — if there's a materially smaller or safer way to the same goal, that
+  is the most valuable thing you can surface. Say it plainly.
+
+## How to say it
+
+- Lead with the verdict: is this plan sound, sound-with-fixes, or should it be rethought? First
+  line, with the reason.
+- If something's wrong, say so directly and up front, with the reason — never soften a real
+  problem into a question or bury it at the end. Hold that position under pushback until a new
+  fact changes it, not until the tone shifts.
+- Separate blocking problems from nits — don't let a naming quibble read as load-bearing.
+- Mark speculation as speculation; distinguish what you verified in the repo from what you
+  suspect. Don't manufacture findings to look thorough — "no blocking issues, two nits" is a
+  complete and useful review.
+
+## Output
+
+Return a structured critique, most-severe first:
+
+- **Verdict** — one line: ship / fix-then-ship / rethink, and why.
+- **Findings** — ranked. Each: what's wrong, why it matters (the concrete failure it leads to),
+  and a specific direction to fix it — a suggestion, not a rewrite of the plan.
+- **Simpler path** — if one exists, the smaller or safer alternative, stated concretely.
+
+You propose; you don't decide. The author takes the critique back and chooses — the same
+propose-before-implement contract you're here to help enforce.

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -17,10 +17,12 @@ color: red
 
 # Plan Reviewer
 
-You are a senior engineer running an adversarial design review. You critique a plan, design, or
-proposed architecture that someone else — the main agent or the user — just produced, in a fresh
-context that did not write it. That independence is the whole point: you bring eyes the author
-can't, catching what reads as obvious-in-hindsight only from outside.
+You are a senior engineer running an adversarial design review. Your job is to break confidence
+in the plan, not validate it: assume it fails in some subtle or expensive way until the plan's own
+evidence says otherwise. You critique a plan, design, or proposed architecture that someone else —
+the main agent or the user — just produced, in a fresh context that did not write it. That
+independence is the whole point: you bring eyes the author can't, catching what reads as
+obvious-in-hindsight only from outside.
 
 You are **read-only**. You never write or edit code, never implement, never open a PR. Your one
 artifact is the critique. Write/Edit aren't in your tool surface — treat that as a structural
@@ -42,14 +44,14 @@ Repo-agnostic: read the conventions here at runtime; never assume another repo's
 
 Rank by how much each would hurt if it shipped:
 
-- **Gaps** — a step the plan needs but doesn't name; a case it doesn't handle (errors, empty
-  input, concurrency, the can't-happen-but-does).
+- **Failure surface** — a step the plan needs but doesn't name; an unhandled failure path; what
+  happens on rollback, a second run, or a partially completed step (idempotency); a race or
+  ordering assumption that stops holding under concurrency; empty or degenerate input; a
+  migration or version-skew hazard. The can't-happen-but-does case.
 - **Unstated assumptions** — a claim the plan rests on that isn't established. Name it, and say
   what breaks if it's false.
-- **Risk & failure modes** — what goes wrong at runtime, on rollback, under load, on a second
-  run; what's expensive to reverse.
-- **Missing considerations** — testing, security, migration/rollback, observability, the next
-  reader — whichever the plan should have addressed and didn't.
+- **Missing considerations** — testing, security, observability, the next reader — whichever the
+  plan should have addressed and didn't.
 - **Boundary & ownership** — logic in the wrong layer, a leaked transport shape, an invariant far
   from its model, an abstraction with a single call site. Judge against this repo's architecture,
   not a generic ideal.
@@ -66,8 +68,10 @@ Rank by how much each would hurt if it shipped:
   problem into a question or bury it at the end. Hold that position under pushback until a new
   fact changes it, not until the tone shifts.
 - Separate blocking problems from nits — don't let a naming quibble read as load-bearing.
-- Mark speculation as speculation; distinguish what you verified in the repo from what you
-  suspect. Don't manufacture findings to look thorough — "no blocking issues, two nits" is a
+- Every finding must be defensible from the plan text or the repo you actually read — never
+  invent a file, a code path, or a runtime behavior you can't point to. Mark speculation as
+  speculation; if a finding depends on an inference, say so explicitly and keep your confidence
+  honest. Don't manufacture findings to look thorough — "no blocking issues, two nits" is a
   complete and useful review.
 
 ## Output

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -9,7 +9,7 @@ description: >-
   it never writes code or files — it only critiques.
 tools: Read, Grep, Glob
 # Judgment-heavy role: capable model, medium effort as the cost control (see
-# claude/rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").
+# rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").
 model: claude-opus-4-8
 effort: medium
 color: red

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -62,6 +62,9 @@ Rank by how much each would hurt if it shipped:
 
 ## How to say it
 
+This section is your role posture — verdict-first adversarial. You read as an AI team member in
+that posture, never as the maintainer; the prose baseline is `communication.md`'s.
+
 - Lead with the verdict: is this plan sound, sound-with-fixes, or should it be rethought? First
   line, with the reason.
 - If something's wrong, say so directly and up front, with the reason — never soften a real

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -8,7 +8,10 @@ description: >-
   plan, design, or refactor. Not for reviewing finished code diffs (that's `/code-review`), and
   it never writes code or files — it only critiques.
 tools: Read, Grep, Glob
+# Judgment-heavy role: capable model, medium effort as the cost control (see
+# claude/rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").
 model: claude-opus-4-8
+effort: medium
 color: red
 ---
 

--- a/rules/domain/architecture.md
+++ b/rules/domain/architecture.md
@@ -1,0 +1,57 @@
+<!-- Application-architecture principles. Canonical source: my dotfiles.
+     Domain-level, NOT universal: applies only when building software with distinct
+     internal layers (a service, a CLI with orchestration, a library with a public
+     contract). For pure config, dotfiles, scripts, or single-purpose tools these do
+     not apply — see the GATE. Language- and platform-agnostic within that scope.
+     Extracted from design-principles.md so it stops loading in non-application repos. -->
+
+> ### GATE
+> Applies only when this repo builds an application with distinct internal layers — a service,
+> a CLI with real orchestration, a library with a public contract. SKIP for pure config,
+> dotfiles, shell scripts, or single-purpose tools: there's no layering for these rules to
+> govern, so they're wrong context there, not merely unnecessary.
+> Like the universal principles, a repo never *overrides* these — a repo's DESIGN.md or ADRs
+> *illustrate* how they're realized in that codebase. Read those and stay consistent; this is
+> the source, the repo doc is the concrete expression. No placeholders, nothing to compose.
+
+# Application Architecture
+
+How code is shaped once a codebase has real internal layers. The universal Design Principles
+(simplicity, self-explaining code, semantic naming, small composable tools) still apply on top of
+these — this file adds only the layer-boundary discipline that a layered application needs and a
+config repo or script does not.
+
+## Layered Design
+
+- **Keep the front end thin.** The entry surface parses input, validates usage, resolves config,
+  composes dependencies, and renders output. It should not own core rules, orchestration, backend
+  quirks, or artifact generation. If logic would still matter behind a different front end, it
+  belongs deeper.
+- **Use-cases own sequencing.** Orchestration layers own stage ordering, typed request/result/error
+  contracts, dependency seams, and the decisions of when to fail and what to emit — not transport
+  parsing or a grab-bag of rules.
+- **Domain before transport.** External systems do not define internal meaning. Normalize external
+  inputs into stable internal models before they reach core logic. Never pass raw transport shapes
+  deep into core logic or reuse them as canonical models.
+- **Keep invariants near the model.** Stable correctness rules belong near the models or validation
+  boundary they protect, not scattered through ad-hoc branching.
+- **Compose at the edge.** Use explicit dependency injection: small interfaces or function seams,
+  runtime selection at the top, lower layers receive dependencies and never discover globals or
+  process state.
+- **Backend quirks stay at the boundary.** Solve an awkward external system as close to its adapter
+  as possible; do not spread its special cases across core logic, presentation, or the front end.
+
+Governing idea: **convert external reality into stable internal meaning as early as possible, and
+keep each layer responsible for exactly one kind of problem.**
+
+## Artifacts Are Contracts
+
+Anything a run emits for a human or downstream tool is part of the contract. Keep artifact generation
+near the serialization boundary; do not let file-format concerns reshape the core model. Declare each
+artifact's meaning explicitly; keep the decision of *when* to emit with the owning use-case and the
+*how* with the output layer.
+
+## Final Rule
+
+If unsure: convert external reality into stable internal meaning as early as possible, and keep
+each layer responsible for one kind of problem.

--- a/rules/domain/architecture.md
+++ b/rules/domain/architecture.md
@@ -4,10 +4,11 @@
      so it stops loading in config/script/dotfiles repos. Rationale: claude/README.md. -->
 
 > ### GATE
+>
 > Applies only when this repo builds an application with distinct internal layers — a service, a
 > CLI with real orchestration, a library with a public contract. SKIP for pure config, dotfiles,
 > scripts, or single-purpose tools: wrong context there, not merely unnecessary.
-> Like the universal principles, a repo's DESIGN.md/ADRs *illustrate* these, never override them.
+> Like the universal principles, a repo's DESIGN.md/ADRs _illustrate_ these, never override them.
 
 # Application Architecture
 

--- a/rules/domain/architecture.md
+++ b/rules/domain/architecture.md
@@ -1,57 +1,32 @@
-<!-- Application-architecture principles. Canonical source: my dotfiles.
-     Domain-level, NOT universal: applies only when building software with distinct
-     internal layers (a service, a CLI with orchestration, a library with a public
-     contract). For pure config, dotfiles, scripts, or single-purpose tools these do
-     not apply — see the GATE. Language- and platform-agnostic within that scope.
-     Extracted from design-principles.md so it stops loading in non-application repos. -->
+<!-- Application-architecture principles. Canonical source: my dotfiles. Domain-level, NOT
+     universal: applies only when building software with distinct internal layers (a service, a
+     CLI with orchestration, a library with a public contract). Extracted from design-principles.md
+     so it stops loading in config/script/dotfiles repos. Rationale: claude/README.md. -->
 
 > ### GATE
-> Applies only when this repo builds an application with distinct internal layers — a service,
-> a CLI with real orchestration, a library with a public contract. SKIP for pure config,
-> dotfiles, shell scripts, or single-purpose tools: there's no layering for these rules to
-> govern, so they're wrong context there, not merely unnecessary.
-> Like the universal principles, a repo never *overrides* these — a repo's DESIGN.md or ADRs
-> *illustrate* how they're realized in that codebase. Read those and stay consistent; this is
-> the source, the repo doc is the concrete expression. No placeholders, nothing to compose.
+> Applies only when this repo builds an application with distinct internal layers — a service, a
+> CLI with real orchestration, a library with a public contract. SKIP for pure config, dotfiles,
+> scripts, or single-purpose tools: wrong context there, not merely unnecessary.
+> Like the universal principles, a repo's DESIGN.md/ADRs *illustrate* these, never override them.
 
 # Application Architecture
 
-How code is shaped once a codebase has real internal layers. The universal Design Principles
-(simplicity, self-explaining code, semantic naming, small composable tools) still apply on top of
-these — this file adds only the layer-boundary discipline that a layered application needs and a
-config repo or script does not.
+The layer-boundary discipline a layered application needs and a config repo or script does not.
+The universal Design Principles still apply on top of these.
 
-## Layered Design
+- **Thin front end.** The entry surface parses input, validates usage, resolves config, composes
+  dependencies, renders output — it doesn't own core rules, orchestration, or backend quirks. If
+  logic would still matter behind a different front end, it belongs deeper.
+- **Use-cases own sequencing.** Orchestration owns stage ordering, typed request/result/error
+  contracts, and when to fail and what to emit — not transport parsing or a grab-bag of rules.
+- **Domain before transport.** Normalize external inputs into stable internal models before they
+  reach core logic; never pass raw transport shapes deep in or reuse them as canonical models.
+- **Invariants near the model**, not scattered through ad-hoc branching.
+- **Compose at the edge.** Explicit dependency injection: small interfaces, runtime selection at
+  the top; lower layers receive dependencies, never discover globals or process state.
+- **Backend quirks stay at the boundary** — solved near their adapter, not spread across core logic.
+- **Artifacts are contracts.** Anything a run emits is part of the contract; keep generation near
+  the serialization boundary, don't let file-format concerns reshape the core model.
 
-- **Keep the front end thin.** The entry surface parses input, validates usage, resolves config,
-  composes dependencies, and renders output. It should not own core rules, orchestration, backend
-  quirks, or artifact generation. If logic would still matter behind a different front end, it
-  belongs deeper.
-- **Use-cases own sequencing.** Orchestration layers own stage ordering, typed request/result/error
-  contracts, dependency seams, and the decisions of when to fail and what to emit — not transport
-  parsing or a grab-bag of rules.
-- **Domain before transport.** External systems do not define internal meaning. Normalize external
-  inputs into stable internal models before they reach core logic. Never pass raw transport shapes
-  deep into core logic or reuse them as canonical models.
-- **Keep invariants near the model.** Stable correctness rules belong near the models or validation
-  boundary they protect, not scattered through ad-hoc branching.
-- **Compose at the edge.** Use explicit dependency injection: small interfaces or function seams,
-  runtime selection at the top, lower layers receive dependencies and never discover globals or
-  process state.
-- **Backend quirks stay at the boundary.** Solve an awkward external system as close to its adapter
-  as possible; do not spread its special cases across core logic, presentation, or the front end.
-
-Governing idea: **convert external reality into stable internal meaning as early as possible, and
-keep each layer responsible for exactly one kind of problem.**
-
-## Artifacts Are Contracts
-
-Anything a run emits for a human or downstream tool is part of the contract. Keep artifact generation
-near the serialization boundary; do not let file-format concerns reshape the core model. Declare each
-artifact's meaning explicitly; keep the decision of *when* to emit with the owning use-case and the
-*how* with the output layer.
-
-## Final Rule
-
-If unsure: convert external reality into stable internal meaning as early as possible, and keep
-each layer responsible for one kind of problem.
+Governing idea: convert external reality into stable internal meaning as early as possible, and
+keep each layer responsible for exactly one kind of problem.

--- a/rules/domain/architecture.md
+++ b/rules/domain/architecture.md
@@ -25,6 +25,9 @@ The universal Design Principles still apply on top of these.
 - **Invariants near the model**, not scattered through ad-hoc branching.
 - **Compose at the edge.** Explicit dependency injection: small interfaces, runtime selection at
   the top; lower layers receive dependencies, never discover globals or process state.
+- **Organize by dependency, not technical layer.** Group modules by the external dependency they
+  wrap (a datastore, a transport), not by a generic role (`models/`, `controllers/`) — the
+  boundary that matters is the dependency being isolated, not the tier.
 - **Backend quirks stay at the boundary** — solved near their adapter, not spread across core logic.
 - **Artifacts are contracts.** Anything a run emits is part of the contract; keep generation near
   the serialization boundary, don't let file-format concerns reshape the core model.

--- a/rules/domain/architecture.md
+++ b/rules/domain/architecture.md
@@ -1,7 +1,7 @@
-<!-- Application-architecture principles. Canonical source: my dotfiles. Domain-level, NOT
+<!-- Application-architecture principles. Canonical source: this repo. Domain-level, NOT
      universal: applies only when building software with distinct internal layers (a service, a
      CLI with orchestration, a library with a public contract). Extracted from design-principles.md
-     so it stops loading in config/script/dotfiles repos. Rationale: claude/README.md. -->
+     so it stops loading in config/script/dotfiles repos. Rationale: README.md. -->
 
 > ### GATE
 >

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -17,11 +17,13 @@
 
 Realizes `git.md`'s workflow on GitHub. No placeholders — `git.md` owns everything composable.
 
-## Squash-merge and branch protection
+## Rebase-merge and branch protection
 
-GitHub squash-merge carries the PR title into the commit message on the protected branch — title
-the PR as a Conventional Commit, per `git.md`. Branch protection (rules/rulesets) is what enforces
-`git.md`'s squash-only merge and required status checks. "PR" is GitHub's review/merge request.
+GitHub rebase-merge replays the branch's commits onto the protected branch as-is — it doesn't
+rewrite the message the way squash-merge does, so the commit itself (already squashed to one,
+already a Conventional Commit subject) is what lands, not the PR title. Branch protection
+(rules/rulesets) is what enforces `git.md`'s single-commit + rebase-merge rule and required status
+checks. "PR" is GitHub's review/merge request.
 
 ## Local tooling
 

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -29,8 +29,10 @@ checks. "PR" is GitHub's review/merge request.
 
 `gh` defaults to a scoped-down fine-grained PAT (contents/PRs/actions read-write, no
 Administration), not a full `gh auth login` session, so routine work can't touch repo settings or
-branch protection — elevate explicitly (`env -u GH_TOKEN gh ...`) only for the one action that
-needs admin. `act` runs the Actions workflows locally via Docker, for testing without pushing.
+branch protection — elevate explicitly (`env -u GH_TOKEN -u GITHUB_TOKEN gh ...` — both vars, since
+a repo aliasing `GITHUB_TOKEN` to the same scoped token means dropping `GH_TOKEN` alone is a no-op)
+only for the one action that needs admin. `act` runs the Actions workflows locally via Docker, for
+testing without pushing.
 
 ## Early draft PRs — `git pr` / `git pr --draft`
 

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -36,11 +36,13 @@ needs admin. `act` runs the Actions workflows locally via Docker, for testing wi
 
 Realizes `git.md`'s "open the PR/MR early, journal via comments" principle on GitHub: `git pr
 --draft` opens a draft PR as soon as a first commit exists (errors loudly instead of guessing if
-one already exists — "did you mean to finalize? run: git pr"); plain `git pr` either opens the
-finalized PR directly (no draft existed yet) or finalizes an already-open one via `gh pr ready`.
-Each path asserts its own precondition — commit count ahead of the base — and fails with a
-specific message rather than branching on ambient state. Journal decisions, gotchas, and
-retractions as comments on the draft PR as work proceeds.
+one already exists — "did you mean to finalize? run: git pr"); plain `git pr` finalizes an
+already-open draft via `gh pr ready`. There's no direct-to-ready path — `git pr` with no draft
+open yet errors, telling the operator to run `git pr --draft` first, matching git.md's rule that
+the draft step is never skipped, even for already-verified work. Each path asserts its own
+precondition — commit count ahead of the base, or draft existence — and fails with a specific
+message rather than branching on ambient state. Journal decisions, gotchas, and retractions as
+comments on the draft PR as work proceeds.
 
 `pr-guards.yml` (see its own inline comments for the exact gate) stays quiet on WIP pushes to an
 early draft and evaluates for real once `git pr` finalizes it — gated per job, not

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -1,12 +1,15 @@
 <!-- GitHub platform mechanics. Canonical source: my dotfiles. Platform-level only: gh CLI,
      GitHub Actions, and GitHub's specific behaviors of the generic git workflow (git.md).
-     Wrong for non-GitHub repos. Assumes git.md's workflow is in effect. Rationale: claude/README.md. -->
+     Wrong for non-GitHub repos. Assumes git.md's workflow is in effect.
+     Rationale: claude/README.md. -->
 
 > ### GATE
+>
 > Applies only if this repo's origin is GitHub (remote points at github.com, or gh is configured
 > for it). Otherwise IGNORE this file — don't apply gh/PR mechanics to a GitLab or other repo.
 
 > ### LOCAL-WINS
+>
 > If this repo has its own GitHub-specific workflow doc, that doc is AUTHORITATIVE: treat this as
 > baseline and prefer the repo's doc on conflict.
 

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -1,54 +1,33 @@
-<!-- GitHub platform mechanics. Canonical source: my dotfiles.
-     Platform-level only: gh CLI, GitHub Actions, and GitHub's specific behaviors of the
-     generic git workflow (git.md). Wrong for non-GitHub (e.g. GitLab) repos —
-     this file assumes git.md's workflow is already in effect and only adds what's
-     specific to this one host. -->
+<!-- GitHub platform mechanics. Canonical source: my dotfiles. Platform-level only: gh CLI,
+     GitHub Actions, and GitHub's specific behaviors of the generic git workflow (git.md).
+     Wrong for non-GitHub repos. Assumes git.md's workflow is in effect. Rationale: claude/README.md. -->
 
 > ### GATE
-> Applies only if this repo's origin is GitHub (git remote points at github.com, or gh CLI
-> is configured for it). Otherwise IGNORE this entire file — do NOT apply gh/PR mechanics to
-> a GitLab or other non-GitHub repo; use that platform's own file instead.
+> Applies only if this repo's origin is GitHub (remote points at github.com, or gh is configured
+> for it). Otherwise IGNORE this file — don't apply gh/PR mechanics to a GitLab or other repo.
 
 > ### LOCAL-WINS
-> If this repo has its own contributing/workflow doc that specifies GitHub-specific rules,
-> that doc is AUTHORITATIVE: treat this as baseline and prefer the repo's doc on conflict.
+> If this repo has its own GitHub-specific workflow doc, that doc is AUTHORITATIVE: treat this as
+> baseline and prefer the repo's doc on conflict.
 
 # GitHub Mechanics
 
-Realizes `git.md`'s generic workflow on GitHub specifically. No repo-specific placeholders
-here — nothing in this file needs composing into a repo doc; `git.md` already owns that.
+Realizes `git.md`'s workflow on GitHub. No placeholders — `git.md` owns everything composable.
 
-## Terminology
+## Squash-merge and branch protection
 
-"PR" (used throughout `git.md`) is GitHub's term for a review/merge request. Branch protection
-here means GitHub's branch-protection rules / rulesets, the mechanism that enforces `git.md`'s
-squash-only merge method and required status checks.
-
-## Squash-merge behavior
-
-On GitHub, squash-merge carries the PR title into the resulting commit message on the protected
-branch — title the PR as a Conventional Commit (`type(scope): subject`), per `git.md`.
+GitHub squash-merge carries the PR title into the commit message on the protected branch — title
+the PR as a Conventional Commit, per `git.md`. Branch protection (rules/rulesets) is what enforces
+`git.md`'s squash-only merge and required status checks. "PR" is GitHub's review/merge request.
 
 ## Local tooling
 
-Concrete instance of `git.md`'s credential-scoping principle: `gh` CLI defaults to a scoped-down
-fine-grained PAT (repo contents/PRs/actions read-write, no Administration) rather than a full
-`gh auth login` session, so routine work can't touch repo settings or branch protection. Elevate
-explicitly (e.g. `env -u GH_TOKEN gh ...`) only for the one action that needs full admin.
-
-`act` runs the GitHub Actions workflows themselves locally (via Docker) — for testing workflow
-changes without pushing and waiting on real CI.
+`gh` defaults to a scoped-down fine-grained PAT (contents/PRs/actions read-write, no
+Administration), not a full `gh auth login` session, so routine work can't touch repo settings or
+branch protection — elevate explicitly (`env -u GH_TOKEN gh ...`) only for the one action that
+needs admin. `act` runs the Actions workflows locally via Docker, for testing without pushing.
 
 ## Releases — gh
 
-Publish notes from the same git-cliff source `git.md`'s Releases section used to build
-`CHANGELOG.md`:
-
-```
-gh release create <TAG> --notes-file <(git cliff --tag <TAG> --latest --strip all)
-```
-
-## Before Finishing, Ask
-
-- Is the PR titled as a Conventional Commit, since GitHub carries it into the squash-merge commit?
-- Is the `gh` session scoped down for routine work, full-admin only when the task actually needs it?
+Publish notes from the same git-cliff source as `git.md`'s Releases:
+`gh release create <TAG> --notes-file <(git cliff --tag <TAG> --latest --strip all)`.

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -42,14 +42,12 @@ Each path asserts its own precondition — commit count ahead of the base — an
 specific message rather than branching on ambient state. Journal decisions, gotchas, and
 retractions as comments on the draft PR as work proceeds.
 
-`pr-guards.yml`'s `single-commit` and `conventional-commit` jobs gate on
-`github.event.pull_request.draft == false`, and `ready_for_review` is added to the `pull_request`
-trigger types alongside `opened`/`reopened`/`synchronize` — so WIP pushes to an early draft
-produce no red noise, and the gate evaluates for real at the moment `git pr` finalizes it. A job
-skipped via a job-level `if:` reads as passing to required-status-check branch protection, not
-failing (verified empirically against this repo's branch protection, not assumed from docs) — a
-workflow-level `if:` that skips the whole run is the sharp edge that can hang a required check
-instead, which this avoids by scoping the `if:` per job.
+`pr-guards.yml` (see its own inline comments for the exact gate) stays quiet on WIP pushes to an
+early draft and evaluates for real once `git pr` finalizes it — gated per job, not
+workflow-level, because a job skipped via a job-level `if:` reads as passing to
+required-status-check branch protection, not failing (verified empirically against this repo's
+branch protection, not assumed from docs), while a workflow-level `if:` that skips the whole run
+is the sharp edge that can hang a required check instead.
 
 ## Releases — gh
 

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -1,0 +1,54 @@
+<!-- GitHub platform mechanics. Canonical source: my dotfiles.
+     Platform-level only: gh CLI, GitHub Actions, and GitHub's specific behaviors of the
+     generic git workflow (git.md). Wrong for non-GitHub (e.g. GitLab) repos —
+     this file assumes git.md's workflow is already in effect and only adds what's
+     specific to this one host. -->
+
+> ### GATE
+> Applies only if this repo's origin is GitHub (git remote points at github.com, or gh CLI
+> is configured for it). Otherwise IGNORE this entire file — do NOT apply gh/PR mechanics to
+> a GitLab or other non-GitHub repo; use that platform's own file instead.
+
+> ### LOCAL-WINS
+> If this repo has its own contributing/workflow doc that specifies GitHub-specific rules,
+> that doc is AUTHORITATIVE: treat this as baseline and prefer the repo's doc on conflict.
+
+# GitHub Mechanics
+
+Realizes `git.md`'s generic workflow on GitHub specifically. No repo-specific placeholders
+here — nothing in this file needs composing into a repo doc; `git.md` already owns that.
+
+## Terminology
+
+"PR" (used throughout `git.md`) is GitHub's term for a review/merge request. Branch protection
+here means GitHub's branch-protection rules / rulesets, the mechanism that enforces `git.md`'s
+squash-only merge method and required status checks.
+
+## Squash-merge behavior
+
+On GitHub, squash-merge carries the PR title into the resulting commit message on the protected
+branch — title the PR as a Conventional Commit (`type(scope): subject`), per `git.md`.
+
+## Local tooling
+
+Concrete instance of `git.md`'s credential-scoping principle: `gh` CLI defaults to a scoped-down
+fine-grained PAT (repo contents/PRs/actions read-write, no Administration) rather than a full
+`gh auth login` session, so routine work can't touch repo settings or branch protection. Elevate
+explicitly (e.g. `env -u GH_TOKEN gh ...`) only for the one action that needs full admin.
+
+`act` runs the GitHub Actions workflows themselves locally (via Docker) — for testing workflow
+changes without pushing and waiting on real CI.
+
+## Releases — gh
+
+Publish notes from the same git-cliff source `git.md`'s Releases section used to build
+`CHANGELOG.md`:
+
+```
+gh release create <TAG> --notes-file <(git cliff --tag <TAG> --latest --strip all)
+```
+
+## Before Finishing, Ask
+
+- Is the PR titled as a Conventional Commit, since GitHub carries it into the squash-merge commit?
+- Is the `gh` session scoped down for routine work, full-admin only when the task actually needs it?

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -32,6 +32,25 @@ Administration), not a full `gh auth login` session, so routine work can't touch
 branch protection — elevate explicitly (`env -u GH_TOKEN gh ...`) only for the one action that
 needs admin. `act` runs the Actions workflows locally via Docker, for testing without pushing.
 
+## Early draft PRs — `git pr` / `git pr --draft`
+
+Realizes `git.md`'s "open the PR/MR early, journal via comments" principle on GitHub: `git pr
+--draft` opens a draft PR as soon as a first commit exists (errors loudly instead of guessing if
+one already exists — "did you mean to finalize? run: git pr"); plain `git pr` either opens the
+finalized PR directly (no draft existed yet) or finalizes an already-open one via `gh pr ready`.
+Each path asserts its own precondition — commit count ahead of the base — and fails with a
+specific message rather than branching on ambient state. Journal decisions, gotchas, and
+retractions as comments on the draft PR as work proceeds.
+
+`pr-guards.yml`'s `single-commit` and `conventional-commit` jobs gate on
+`github.event.pull_request.draft == false`, and `ready_for_review` is added to the `pull_request`
+trigger types alongside `opened`/`reopened`/`synchronize` — so WIP pushes to an early draft
+produce no red noise, and the gate evaluates for real at the moment `git pr` finalizes it. A job
+skipped via a job-level `if:` reads as passing to required-status-check branch protection, not
+failing (verified empirically against this repo's branch protection, not assumed from docs) — a
+workflow-level `if:` that skips the whole run is the sharp edge that can hang a required check
+instead, which this avoids by scoping the `if:` per job.
+
 ## Releases — gh
 
 Publish notes from the same git-cliff source as `git.md`'s Releases:

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -36,3 +36,17 @@ needs admin. `act` runs the Actions workflows locally via Docker, for testing wi
 
 Publish notes from the same git-cliff source as `git.md`'s Releases:
 `gh release create <TAG> --notes-file <(git cliff --tag <TAG> --latest --strip all)`.
+
+## Changelog PR links — git-cliff GitHub remote
+
+Realizes `git.md`'s "resolve PR links via the host's API" principle on GitHub: `cliff.toml`'s
+`[git]` section sets `commit_preprocessors` to strip any legacy "(#N)" text instead of linking it,
+and a `[remote.github]` section (`owner`, `repo`) plus a template using `commit.remote.pr_number`
+resolve the link at generation time. Never put a token in `[remote.github]`'s `token` field — pass
+it via the `GITHUB_TOKEN` env var (or `--github-token`) at invocation time instead, same as any
+other secret. `git-cliff` specifically wants `GITHUB_TOKEN`, not `gh`'s `GH_TOKEN` — alias it to
+whatever scoped token this repo's credential setup already provides (`git.md`'s credential-scoping
+principle) rather than introducing a second one. In CI, wire `GITHUB_TOKEN` (the default token, or
+the release credential already in scope) into every workflow step that invokes `git cliff`.
+Unauthenticated GitHub API is 60 req/hr — a token raises that to a workable ceiling for a
+full-history regeneration.

--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -1,7 +1,7 @@
-<!-- GitHub platform mechanics. Canonical source: my dotfiles. Platform-level only: gh CLI,
+<!-- GitHub platform mechanics. Canonical source: this repo. Platform-level only: gh CLI,
      GitHub Actions, and GitHub's specific behaviors of the generic git workflow (git.md).
      Wrong for non-GitHub repos. Assumes git.md's workflow is in effect.
-     Rationale: claude/README.md. -->
+     Rationale: README.md. -->
 
 > ### GATE
 >

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -17,10 +17,10 @@
 >
 > Trigger: the human asks to scaffold, OR a repo lacks a stated workflow and one is warranted.
 > PROPOSE, don't create — suggest and wait. Steps: (1) read this as baseline; (2) write a
-> repo-local doc filling the <placeholders> — <scopes>, <version-scheme>,
-> <long-lived-branch>/<protected-branch>, whether release automation applies; (3) add to the
-> repo's AGENTS.md that its workflow doc is authoritative over generic git conventions (name no
-> personal path); (4) after this the repo reads its own doc — don't re-distill.
+> repo-local doc filling the <placeholders> — <scopes>, <version-scheme>, <protected-branch>,
+> whether release automation applies; (3) add to the repo's AGENTS.md that its workflow doc is
+> authoritative over generic git conventions (name no personal path); (4) after this the repo
+> reads its own doc — don't re-distill.
 
 # Git Workflow
 
@@ -46,19 +46,22 @@ commit; propose the split before committing.
   branch, and it aborts if the remote moved. If the remote moved unexpectedly, stop and inspect
   before anything destructive — realign, don't overwrite.
 
-## Branch & PR model — long-lived working branch + protected main, squash-merged
+## Branch & PR model — short-lived feature branches + protected main, rebase-merged
 
-1. Fetch and check the remote <long-lived-branch>/<protected-branch> before substantial work — a
-   stale base means painful divergence later.
-2. Work on <long-lived-branch>, committing freely (WIP commits get squashed).
-3. One logical change per PR — under squash-merge one PR is one commit on <protected-branch>. Never
-   bundle unrelated changes to save a round trip.
-4. When ready and tested, PR → <protected-branch>, CI passes, **squash-merge**. Title the PR as a
-   Conventional Commit — most hosts carry it into the commit message.
-5. After merge, reset the working branch onto the protected branch so histories don't drift:
-   `git switch <long-lived-branch> && git reset --hard origin/<protected-branch> && git push --force-with-lease origin <long-lived-branch>`. <!-- markdownlint-disable-line MD013 -->
-   Local automation pushing to it should auto-rebase onto latest remote, not fail on rejection.
-6. The protected branch stays releasable, never committed to directly. Merge method is squash only.
+1. Fetch and check the remote <protected-branch> before branching — a stale base means painful
+   divergence later. Branch off it per change; the branch is single-use and short-lived.
+2. Commit freely on the feature branch — WIP commits needn't follow the commit style, since only
+   the final squashed commit reaches <protected-branch>.
+3. One logical change per PR. Never bundle unrelated changes to save a round trip.
+4. When ready and tested, squash the branch to exactly one Conventional Commit
+   (`git reset --soft origin/<protected-branch> && git commit`), then PR → <protected-branch>. CI
+   gates on the PR being exactly one commit with a Conventional-Commit subject — the two checks
+   rebase-merge relies on, since the host won't rewrite the message the way squash-merge would.
+5. Once green, **rebase-merge**: your single commit lands on <protected-branch> verbatim, and the
+   branch auto-deletes. No branch reuse or reset step needed — the next change starts a fresh
+   branch off <protected-branch>.
+6. <protected-branch> stays releasable, never committed to directly. Merge method is rebase-merge
+   only, enforced by the single-commit + Conventional-Commit checks.
 
 ## Working iteratively when you can't self-verify
 
@@ -78,6 +81,6 @@ version/changelog release automation would compute, with zero side effects — r
 
 ## Releases (if the repo versions releases) — git-cliff
 
-Cut <version-scheme> from Conventional Commits: on the working branch `git cliff --tag <TAG> -o
-CHANGELOG.md`, commit as `chore(release): <TAG>`, PR, squash-merge, then `git tag -a <TAG> -m <TAG>
+Cut <version-scheme> from Conventional Commits: on a release branch `git cliff --tag <TAG> -o
+CHANGELOG.md`, commit as `chore(release): <TAG>`, PR, rebase-merge, then `git tag -a <TAG> -m <TAG>
 && git push origin <TAG>`. Publishing notes is host-specific — see the platform file.

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -1,0 +1,133 @@
+<!-- Git workflow mechanics, platform-agnostic. Canonical source: my dotfiles.
+     VCS-level only: works the same on GitHub, GitLab, Bitbucket, or a bare remote.
+     Platform-specific realization (gh/glab CLI, GitHub Actions, a host's specific
+     squash-merge behavior) lives in the platform file instead (e.g. github.md). -->
+
+> ### GATE
+> Applies only if this repo uses git — true for nearly every repo, so this is the
+> rare-exception gate, not a real filter. If somehow not, ignore this entire file.
+
+> ### LOCAL-WINS
+> If this repo has its own contributing/workflow doc that specifies commit or branch rules,
+> that doc is AUTHORITATIVE: treat this as baseline and prefer the repo's doc on conflict.
+
+> ### COMPOSE — how to give a repo its own concrete git workflow doc
+> Trigger: only when the human asks to scaffold, OR a repo lacks a stated commit/branch
+> workflow and one is warranted. Default to PROPOSE, don't create — suggest and wait before
+> writing committed files.
+> Steps:
+>   1. Read this once as the baseline.
+>   2. Write a repo-local doc (or an AGENTS.md section) that fills the <placeholders> with
+>      this repo's real values: <scopes> (its module/area names), <version-scheme>, the
+>      <long-lived-branch>/<protected-branch> names, and whether release automation applies.
+>   3. Wire the gate so local wins: add to the repo's committed AGENTS.md:
+>        "This repo's workflow doc is authoritative for commit/branch rules; treat any
+>         generic git conventions as baseline and prefer this repo's doc on conflict."
+>      (Names NO personal path — commit-safe, true for any contributor.)
+>   4. After this, the repo reads its own doc; do not re-distill this for that repo.
+
+# Git Workflow
+
+Mechanics for realizing my version-control discipline with plain git — true regardless of
+hosting platform. Repo-specific values (commit scopes, version scheme, branch names) fill the
+<placeholders> and live in the repo. "PR" below means a pull or merge request, whichever your
+host calls it.
+
+## Commits — Conventional Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Every commit:
+
+- **Subject** `type(scope): description`
+  - `type` ∈ feat, fix, docs, style, refactor, perf, test, build, ci, chore
+  - `scope` (optional): a repo area from this repo's <scopes>
+  - `description`: imperative, lowercase, no trailing period; ≤50 chars where possible
+    (hard limit 72)
+  - Breaking change: `type!:` or a `BREAKING CHANGE:` footer
+- **Blank line**, then a **body** wrapped at 72 chars explaining *what* and *why*, never
+  *how* (the diff shows how). Omit only for trivial, self-evident changes.
+- **Trailers** (optional): `Co-authored-by: Name <email>` per human contributor. Do NOT add
+  AI/assistant attribution.
+
+Scope each commit to one logical change — prefer several focused commits over one sweeping
+commit. Propose the split and messages before committing.
+
+## Version Control Discipline
+
+- **Review before committing.** Don't commit or push on your own initiative; show what changed and
+  get explicit approval, then commit only what was approved.
+- **Commit freely while developing** on the working branch; intermediate checkpoints are expected.
+- **Main-line history is clean.** Each merged change is one clear, complete, squashed commit
+  describing the whole change — not its iteration history.
+- **Rebase onto latest main-line before merging.**
+- **Never rewrite history you don't own.** The only sanctioned force-push is the deliberate rewrite
+  of your own just-squashed branch, and it must abort if the remote moved unexpectedly.
+- If the remote moved unexpectedly, stop and inspect before doing anything destructive; realign
+  rather than overwrite.
+
+## Branch & PR model — long-lived working branch + protected main, squash-merged
+
+0. Fetch and check the remote <long-lived-branch>/<protected-branch> state before starting
+   substantial work. Building several commits on a stale base causes painful divergence and
+   rebase conflicts later — cheaper to catch upfront.
+1. All work happens on the <long-lived-branch> — commit freely and messily; WIP commits need
+   not follow commit style (they get squashed away).
+2. Scope each PR to one logical change. Under squash-merge one PR = one commit on
+   <protected-branch>, so a focused PR yields a clean, atomic, revertable commit. Never bundle
+   unrelated changes into one PR to save a round trip.
+3. When ready and tested, open a PR <long-lived-branch> → <protected-branch>. CI must pass, then
+   **squash-merge**. Title the PR as a Conventional Commit (`type(scope): subject`) — most hosts
+   carry the PR title into the resulting commit message on squash-merge.
+4. After merge, reset the working branch onto the protected branch so histories don't drift:
+   `git switch <long-lived-branch> && git reset --hard origin/<protected-branch> && git push --force-with-lease origin <long-lived-branch>`
+   This periodically rewrites the working branch out from under anyone still on an older commit —
+   local automation that pushes to it should auto-rebase onto the latest remote state rather than
+   just fail on a rejected push.
+5. The protected branch stays releasable and is never committed to directly (except one-time
+   bootstraps). Merge method is **squash only**.
+
+## Working iteratively when you can't self-verify
+
+Some changes can't be confirmed by the agent alone — GUI apps, interactive TUIs, visual
+rendering, keybinding behavior. For that kind of work:
+
+- Commit locally on the <long-lived-branch> as a checkpoint between attempts, but hold off on
+  push/PR until the change is actually confirmed working. Each PR round-trip (CI, merge, branch
+  reset/sync) is real overhead to pay for something still unvalidated.
+- Once confirmed, squash the iteration into one commit representing the final validated state —
+  not the trial-and-error path to get there — then push → PR → merge once.
+- Squash the working branch to one commit before opening the PR even for self-verifiable work
+  (`git reset --soft origin/<protected-branch> && git commit`). A PR showing twenty WIP commits
+  is hard to review, even though squash-merge collapses them anyway.
+
+Work verifiable directly — syntax checks, a dry run, non-interactive CLI behavior — doesn't need
+this; the normal per-change cadence is fine there.
+
+## Shift-left tooling and credential scope
+
+Mirror what CI enforces locally (pre-commit hooks or equivalent) so failures surface before push,
+not after — the same checks CI runs, not a subset that drifts from them.
+
+Scope the day-to-day credential (a CLI token, not a full-admin auth session) down to what routine
+commits/PRs actually need, so an agent driving the host's CLI can't accidentally touch repo
+settings, branch protection, or other administrative surfaces. Elevate explicitly only for the
+one action that needs it. (Concrete instance for GitHub: the platform `github.md` file.)
+
+`git cliff --bump` is worth reaching for by hand, not wired into any hook: preview the exact
+version/changelog release automation would produce, with zero side effects, before triggering it
+for real.
+
+## Releases (if the repo versions releases) — git-cliff
+
+Cut <version-scheme> (e.g. [SemVer](https://semver.org)) from Conventional Commits:
+
+- On the working branch: `git cliff --tag <TAG> -o CHANGELOG.md`, commit as
+  `chore(release): <TAG>`, PR, squash-merge.
+- Tag it: `git tag -a <TAG> -m <TAG> && git push origin <TAG>`.
+- Publishing the release itself (notes, a release page) is host-specific — see the
+  platform file.
+
+## Before Finishing, Ask
+
+- Did I fetch and check the remote before starting substantial work?
+- Is this PR scoped to one logical change, with commits following Conventional Commits?
+- For unvalidated/unverifiable work, did I hold off on push/PR until it's actually confirmed?

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -1,133 +1,80 @@
 <!-- Git workflow mechanics, platform-agnostic. Canonical source: my dotfiles.
-     VCS-level only: works the same on GitHub, GitLab, Bitbucket, or a bare remote.
-     Platform-specific realization (gh/glab CLI, GitHub Actions, a host's specific
-     squash-merge behavior) lives in the platform file instead (e.g. github.md). -->
+     VCS-level only: same on GitHub, GitLab, Bitbucket, or a bare remote. Platform specifics
+     (gh/glab, Actions, a host's squash-merge behavior) live in the platform file (github.md).
+     Rationale: claude/README.md. -->
 
 > ### GATE
-> Applies only if this repo uses git — true for nearly every repo, so this is the
-> rare-exception gate, not a real filter. If somehow not, ignore this entire file.
+> Applies only if this repo uses git — true for nearly every repo, so this is the rare-exception
+> gate, not a real filter. If not, ignore this file.
 
 > ### LOCAL-WINS
-> If this repo has its own contributing/workflow doc that specifies commit or branch rules,
-> that doc is AUTHORITATIVE: treat this as baseline and prefer the repo's doc on conflict.
+> If this repo has its own commit/branch-workflow doc, that doc is AUTHORITATIVE: treat this as
+> baseline and prefer the repo's doc on conflict.
 
-> ### COMPOSE — how to give a repo its own concrete git workflow doc
-> Trigger: only when the human asks to scaffold, OR a repo lacks a stated commit/branch
-> workflow and one is warranted. Default to PROPOSE, don't create — suggest and wait before
-> writing committed files.
-> Steps:
->   1. Read this once as the baseline.
->   2. Write a repo-local doc (or an AGENTS.md section) that fills the <placeholders> with
->      this repo's real values: <scopes> (its module/area names), <version-scheme>, the
->      <long-lived-branch>/<protected-branch> names, and whether release automation applies.
->   3. Wire the gate so local wins: add to the repo's committed AGENTS.md:
->        "This repo's workflow doc is authoritative for commit/branch rules; treat any
->         generic git conventions as baseline and prefer this repo's doc on conflict."
->      (Names NO personal path — commit-safe, true for any contributor.)
->   4. After this, the repo reads its own doc; do not re-distill this for that repo.
+> ### COMPOSE — give a repo its own concrete git workflow doc
+> Trigger: the human asks to scaffold, OR a repo lacks a stated workflow and one is warranted.
+> PROPOSE, don't create — suggest and wait. Steps: (1) read this as baseline; (2) write a
+> repo-local doc filling the <placeholders> — <scopes>, <version-scheme>,
+> <long-lived-branch>/<protected-branch>, whether release automation applies; (3) add to the
+> repo's AGENTS.md that its workflow doc is authoritative over generic git conventions (name no
+> personal path); (4) after this the repo reads its own doc — don't re-distill.
 
 # Git Workflow
 
-Mechanics for realizing my version-control discipline with plain git — true regardless of
-hosting platform. Repo-specific values (commit scopes, version scheme, branch names) fill the
-<placeholders> and live in the repo. "PR" below means a pull or merge request, whichever your
-host calls it.
+Repo-specific values (scopes, version scheme, branch names) fill the <placeholders> and live in
+the repo. "PR" means a pull or merge request, whichever your host calls it.
 
 ## Commits — Conventional Commits
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Every commit:
-
-- **Subject** `type(scope): description`
-  - `type` ∈ feat, fix, docs, style, refactor, perf, test, build, ci, chore
-  - `scope` (optional): a repo area from this repo's <scopes>
-  - `description`: imperative, lowercase, no trailing period; ≤50 chars where possible
-    (hard limit 72)
-  - Breaking change: `type!:` or a `BREAKING CHANGE:` footer
-- **Blank line**, then a **body** wrapped at 72 chars explaining *what* and *why*, never
-  *how* (the diff shows how). Omit only for trivial, self-evident changes.
-- **Trailers** (optional): `Co-authored-by: Name <email>` per human contributor. Do NOT add
-  AI/assistant attribution.
-
-Scope each commit to one logical change — prefer several focused commits over one sweeping
-commit. Propose the split and messages before committing.
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/): `type(scope): description`,
+imperative lowercase subject ≤50 chars (hard limit 72); `type` ∈ feat/fix/docs/style/refactor/perf/
+test/build/ci/chore; `scope` from this repo's <scopes>. Breaking change: `type!:` or a
+`BREAKING CHANGE:` footer. Blank line, then a body wrapped at 72 explaining *what* and *why*, never
+*how*. `Co-authored-by:` per human contributor; never AI attribution. One logical change per
+commit; propose the split before committing.
 
 ## Version Control Discipline
 
-- **Review before committing.** Don't commit or push on your own initiative; show what changed and
-  get explicit approval, then commit only what was approved.
-- **Commit freely while developing** on the working branch; intermediate checkpoints are expected.
-- **Main-line history is clean.** Each merged change is one clear, complete, squashed commit
-  describing the whole change — not its iteration history.
-- **Rebase onto latest main-line before merging.**
-- **Never rewrite history you don't own.** The only sanctioned force-push is the deliberate rewrite
-  of your own just-squashed branch, and it must abort if the remote moved unexpectedly.
-- If the remote moved unexpectedly, stop and inspect before doing anything destructive; realign
-  rather than overwrite.
+- Don't commit or push on your own initiative — show what changed, get approval, commit only that.
+- Commit freely on the working branch; main-line history stays clean (one squashed commit per
+  merged change, not its iteration history).
+- Rebase onto latest main-line before merging.
+- Never rewrite history you don't own. The only sanctioned force-push is your own just-squashed
+  branch, and it aborts if the remote moved. If the remote moved unexpectedly, stop and inspect
+  before anything destructive — realign, don't overwrite.
 
 ## Branch & PR model — long-lived working branch + protected main, squash-merged
 
-0. Fetch and check the remote <long-lived-branch>/<protected-branch> state before starting
-   substantial work. Building several commits on a stale base causes painful divergence and
-   rebase conflicts later — cheaper to catch upfront.
-1. All work happens on the <long-lived-branch> — commit freely and messily; WIP commits need
-   not follow commit style (they get squashed away).
-2. Scope each PR to one logical change. Under squash-merge one PR = one commit on
-   <protected-branch>, so a focused PR yields a clean, atomic, revertable commit. Never bundle
-   unrelated changes into one PR to save a round trip.
-3. When ready and tested, open a PR <long-lived-branch> → <protected-branch>. CI must pass, then
-   **squash-merge**. Title the PR as a Conventional Commit (`type(scope): subject`) — most hosts
-   carry the PR title into the resulting commit message on squash-merge.
-4. After merge, reset the working branch onto the protected branch so histories don't drift:
-   `git switch <long-lived-branch> && git reset --hard origin/<protected-branch> && git push --force-with-lease origin <long-lived-branch>`
-   This periodically rewrites the working branch out from under anyone still on an older commit —
-   local automation that pushes to it should auto-rebase onto the latest remote state rather than
-   just fail on a rejected push.
-5. The protected branch stays releasable and is never committed to directly (except one-time
-   bootstraps). Merge method is **squash only**.
+1. Fetch and check the remote <long-lived-branch>/<protected-branch> before substantial work — a
+   stale base means painful divergence later.
+2. Work on <long-lived-branch>, committing freely (WIP commits get squashed).
+3. One logical change per PR — under squash-merge one PR is one commit on <protected-branch>. Never
+   bundle unrelated changes to save a round trip.
+4. When ready and tested, PR → <protected-branch>, CI passes, **squash-merge**. Title the PR as a
+   Conventional Commit — most hosts carry it into the commit message.
+5. After merge, reset the working branch onto the protected branch so histories don't drift:
+   `git switch <long-lived-branch> && git reset --hard origin/<protected-branch> && git push --force-with-lease origin <long-lived-branch>`.
+   Local automation pushing to it should auto-rebase onto latest remote, not fail on rejection.
+6. The protected branch stays releasable, never committed to directly. Merge method is squash only.
 
 ## Working iteratively when you can't self-verify
 
-Some changes can't be confirmed by the agent alone — GUI apps, interactive TUIs, visual
-rendering, keybinding behavior. For that kind of work:
-
-- Commit locally on the <long-lived-branch> as a checkpoint between attempts, but hold off on
-  push/PR until the change is actually confirmed working. Each PR round-trip (CI, merge, branch
-  reset/sync) is real overhead to pay for something still unvalidated.
-- Once confirmed, squash the iteration into one commit representing the final validated state —
-  not the trial-and-error path to get there — then push → PR → merge once.
-- Squash the working branch to one commit before opening the PR even for self-verifiable work
-  (`git reset --soft origin/<protected-branch> && git commit`). A PR showing twenty WIP commits
-  is hard to review, even though squash-merge collapses them anyway.
-
-Work verifiable directly — syntax checks, a dry run, non-interactive CLI behavior — doesn't need
-this; the normal per-change cadence is fine there.
+For changes the agent can't confirm alone (GUI, TUI, rendering, keybindings): commit locally as
+checkpoints but hold off push/PR until confirmed — each round-trip is real overhead for something
+unvalidated. Once confirmed, squash to one commit for the final state and push → PR → merge once.
+Squash before any PR (`git reset --soft origin/<protected-branch> && git commit`) — a twenty-WIP
+PR is hard to review. Directly-verifiable work (syntax, dry run, CLI) skips this.
 
 ## Shift-left tooling and credential scope
 
-Mirror what CI enforces locally (pre-commit hooks or equivalent) so failures surface before push,
-not after — the same checks CI runs, not a subset that drifts from them.
-
-Scope the day-to-day credential (a CLI token, not a full-admin auth session) down to what routine
-commits/PRs actually need, so an agent driving the host's CLI can't accidentally touch repo
-settings, branch protection, or other administrative surfaces. Elevate explicitly only for the
-one action that needs it. (Concrete instance for GitHub: the platform `github.md` file.)
-
-`git cliff --bump` is worth reaching for by hand, not wired into any hook: preview the exact
-version/changelog release automation would produce, with zero side effects, before triggering it
-for real.
+Mirror what CI enforces locally (pre-commit or equivalent) — the same checks, not a drifting
+subset. Scope the day-to-day credential (a CLI token, not a full-admin session) to what routine
+commits/PRs need, so an agent driving the host CLI can't touch repo settings or branch protection;
+elevate explicitly only for the one action that needs it. `git cliff --bump` previews the exact
+version/changelog release automation would compute, with zero side effects — reach for it by hand.
 
 ## Releases (if the repo versions releases) — git-cliff
 
-Cut <version-scheme> (e.g. [SemVer](https://semver.org)) from Conventional Commits:
-
-- On the working branch: `git cliff --tag <TAG> -o CHANGELOG.md`, commit as
-  `chore(release): <TAG>`, PR, squash-merge.
-- Tag it: `git tag -a <TAG> -m <TAG> && git push origin <TAG>`.
-- Publishing the release itself (notes, a release page) is host-specific — see the
-  platform file.
-
-## Before Finishing, Ask
-
-- Did I fetch and check the remote before starting substantial work?
-- Is this PR scoped to one logical change, with commits following Conventional Commits?
-- For unvalidated/unverifiable work, did I hold off on push/PR until it's actually confirmed?
+Cut <version-scheme> from Conventional Commits: on the working branch `git cliff --tag <TAG> -o
+CHANGELOG.md`, commit as `chore(release): <TAG>`, PR, squash-merge, then `git tag -a <TAG> -m <TAG>
+&& git push origin <TAG>`. Publishing notes is host-specific — see the platform file.

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -71,14 +71,19 @@ commit; propose the split before committing.
 ## Working iteratively when you can't self-verify
 
 Open-PR-early (step 2) still applies here — the draft PR opens at the first commit regardless of
-how verifiable the change is. What this section scopes is _finalizing_ (marking ready for
-review): for changes the agent can't confirm alone (GUI, TUI, rendering, keybindings), push
-checkpoints and journal decisions on the draft PR as work proceeds, but hold off finalizing until
-the change is confirmed working — each review round-trip on something unvalidated is real
+how verifiable the change is, with no exception: always open it via the draft path (e.g.
+`git pr --draft`), never the plain/no-flag path, even when the change is already done and
+verified. What this section scopes is _finalizing_ (marking ready for review), not whether a
+draft opens at all: for changes the agent can't confirm alone (GUI, TUI, rendering, keybindings),
+push checkpoints and journal decisions on the draft PR as work proceeds, but hold off finalizing
+until the change is confirmed working — each review round-trip on something unvalidated is real
 overhead. Once confirmed, squash to one commit (`git reset --soft origin/<protected-branch> &&
 git commit`) and finalize — a twenty-WIP-commit PR is hard to review, so the squash happens right
-before finalizing, not before the PR opens. Directly-verifiable work (syntax, dry run, CLI) skips
-the hold-off: squash and finalize as soon as it passes verification.
+before finalizing, not before the PR opens. Directly-verifiable work (syntax, dry run, CLI) still
+opens as a draft first, exactly like anything else; it only skips the _hold-off before
+finalizing_: squash and finalize immediately once it passes verification, as a second, explicit
+step right after the draft opens — not a shortcut that skips opening as a draft in the first
+place.
 
 ## Shift-left tooling and credential scope
 

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -70,11 +70,15 @@ commit; propose the split before committing.
 
 ## Working iteratively when you can't self-verify
 
-For changes the agent can't confirm alone (GUI, TUI, rendering, keybindings): commit locally as
-checkpoints but hold off push/PR until confirmed — each round-trip is real overhead for something
-unvalidated. Once confirmed, squash to one commit for the final state and push → PR → merge once.
-Squash before any PR (`git reset --soft origin/<protected-branch> && git commit`) — a twenty-WIP
-PR is hard to review. Directly-verifiable work (syntax, dry run, CLI) skips this.
+Open-PR-early (step 2) still applies here — the draft PR opens at the first commit regardless of
+how verifiable the change is. What this section scopes is _finalizing_ (marking ready for
+review): for changes the agent can't confirm alone (GUI, TUI, rendering, keybindings), push
+checkpoints and journal decisions on the draft PR as work proceeds, but hold off finalizing until
+the change is confirmed working — each review round-trip on something unvalidated is real
+overhead. Once confirmed, squash to one commit (`git reset --soft origin/<protected-branch> &&
+git commit`) and finalize — a twenty-WIP-commit PR is hard to review, so the squash happens right
+before finalizing, not before the PR opens. Directly-verifiable work (syntax, dry run, CLI) skips
+the hold-off: squash and finalize as soon as it passes verification.
 
 ## Shift-left tooling and credential scope
 

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -73,17 +73,15 @@ commit; propose the split before committing.
 Open-PR-early (step 2) still applies here — the draft PR opens at the first commit regardless of
 how verifiable the change is, with no exception: always open it via the draft path (e.g.
 `git pr --draft`), never the plain/no-flag path, even when the change is already done and
-verified. What this section scopes is _finalizing_ (marking ready for review), not whether a
-draft opens at all: for changes the agent can't confirm alone (GUI, TUI, rendering, keybindings),
-push checkpoints and journal decisions on the draft PR as work proceeds, but hold off finalizing
-until the change is confirmed working — each review round-trip on something unvalidated is real
-overhead. Once confirmed, squash to one commit (`git reset --soft origin/<protected-branch> &&
-git commit`) and finalize — a twenty-WIP-commit PR is hard to review, so the squash happens right
-before finalizing, not before the PR opens. Directly-verifiable work (syntax, dry run, CLI) still
-opens as a draft first, exactly like anything else; it only skips the _hold-off before
-finalizing_: squash and finalize immediately once it passes verification, as a second, explicit
-step right after the draft opens — not a shortcut that skips opening as a draft in the first
-place.
+verified. What this section scopes is _finalizing_ (marking ready for review): draft means the
+agent is still working, ready-for-review means it's the human's turn — that handoff is itself the
+"your turn" signal, so squash to one commit (`git reset --soft origin/<protected-branch> && git
+commit`) and finalize at handoff for all work, verifiable or not. For changes the agent can't
+confirm alone (GUI, TUI, rendering, keybindings), the human's confirmation folds into reviewing
+the ready PR rather than gating the flip to ready — finalizing also triggers CI, so the human
+picks it up with checks already run. Staying in draft at handoff is the explicit exception, not
+the default: only when the agent specifically needs the human to test something _before_ code
+review can happen, and it says so in the handoff message.
 
 ## Shift-left tooling and credential scope
 

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -4,14 +4,17 @@
      Rationale: claude/README.md. -->
 
 > ### GATE
+>
 > Applies only if this repo uses git — true for nearly every repo, so this is the rare-exception
 > gate, not a real filter. If not, ignore this file.
 
 > ### LOCAL-WINS
+>
 > If this repo has its own commit/branch-workflow doc, that doc is AUTHORITATIVE: treat this as
 > baseline and prefer the repo's doc on conflict.
 
 > ### COMPOSE — give a repo its own concrete git workflow doc
+>
 > Trigger: the human asks to scaffold, OR a repo lacks a stated workflow and one is warranted.
 > PROPOSE, don't create — suggest and wait. Steps: (1) read this as baseline; (2) write a
 > repo-local doc filling the <placeholders> — <scopes>, <version-scheme>,
@@ -29,8 +32,8 @@ the repo. "PR" means a pull or merge request, whichever your host calls it.
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/): `type(scope): description`,
 imperative lowercase subject ≤50 chars (hard limit 72); `type` ∈ feat/fix/docs/style/refactor/perf/
 test/build/ci/chore; `scope` from this repo's <scopes>. Breaking change: `type!:` or a
-`BREAKING CHANGE:` footer. Blank line, then a body wrapped at 72 explaining *what* and *why*, never
-*how*. `Co-authored-by:` per human contributor; never AI attribution. One logical change per
+`BREAKING CHANGE:` footer. Blank line, then a body wrapped at 72 explaining _what_ and _why_, never
+_how_. `Co-authored-by:` per human contributor; never AI attribution. One logical change per
 commit; propose the split before committing.
 
 ## Version Control Discipline
@@ -53,7 +56,7 @@ commit; propose the split before committing.
 4. When ready and tested, PR → <protected-branch>, CI passes, **squash-merge**. Title the PR as a
    Conventional Commit — most hosts carry it into the commit message.
 5. After merge, reset the working branch onto the protected branch so histories don't drift:
-   `git switch <long-lived-branch> && git reset --hard origin/<protected-branch> && git push --force-with-lease origin <long-lived-branch>`.
+   `git switch <long-lived-branch> && git reset --hard origin/<protected-branch> && git push --force-with-lease origin <long-lived-branch>`. <!-- markdownlint-disable-line MD013 -->
    Local automation pushing to it should auto-rebase onto latest remote, not fail on rejection.
 6. The protected branch stays releasable, never committed to directly. Merge method is squash only.
 

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -78,9 +78,19 @@ subset. Scope the day-to-day credential (a CLI token, not a full-admin session) 
 commits/PRs need, so an agent driving the host CLI can't touch repo settings or branch protection;
 elevate explicitly only for the one action that needs it. `git cliff --bump` previews the exact
 version/changelog release automation would compute, with zero side effects — reach for it by hand.
+If the repo's changelog resolves PR links via the host's API (below), this preview is
+network-dependent by default; `--offline` (or `GIT_CLIFF_OFFLINE`) skips those lookups when that
+matters.
 
 ## Releases (if the repo versions releases) — git-cliff
 
 Cut <version-scheme> from Conventional Commits: on a release branch `git cliff --tag <TAG> -o
 CHANGELOG.md`, commit as `chore(release): <TAG>`, PR, rebase-merge, then `git tag -a <TAG> -m <TAG>
 && git push origin <TAG>`. Publishing notes is host-specific — see the platform file.
+
+Resolve PR/MR changelog links via the host's API at changelog-generation time, not by encoding
+them into the commit message: rebase-merge (or any strategy that preserves the author's SHA)
+means a pre-merge text convention can't survive history rewrites the host itself doesn't do, but
+the host tracks the commit↔PR association server-side regardless of merge strategy, so a
+generation-time lookup is the durable source, not the commit text. Host-specific config lives in
+the platform file.

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -50,17 +50,22 @@ commit; propose the split before committing.
 
 1. Fetch and check the remote <protected-branch> before branching — a stale base means painful
    divergence later. Branch off it per change; the branch is single-use and short-lived.
-2. Commit freely on the feature branch — WIP commits needn't follow the commit style, since only
+2. Open the PR/MR as soon as a branch and first commit exist, not after the final squash. Journal
+   decisions, gotchas, decision forks, and retractions as PR/MR comments while work proceeds — the
+   PR/MR becomes the real-time record, not a postmortem written at the end. Host-specific mechanics
+   for keeping checks quiet during this early/WIP window live in the platform file.
+3. Commit freely on the feature branch — WIP commits needn't follow the commit style, since only
    the final squashed commit reaches <protected-branch>.
-3. One logical change per PR. Never bundle unrelated changes to save a round trip.
-4. When ready and tested, squash the branch to exactly one Conventional Commit
-   (`git reset --soft origin/<protected-branch> && git commit`), then PR → <protected-branch>. CI
-   gates on the PR being exactly one commit with a Conventional-Commit subject — the two checks
-   rebase-merge relies on, since the host won't rewrite the message the way squash-merge would.
-5. Once green, **rebase-merge**: your single commit lands on <protected-branch> verbatim, and the
+4. One logical change per PR. Never bundle unrelated changes to save a round trip.
+5. When ready and tested, squash the branch to exactly one Conventional Commit
+   (`git reset --soft origin/<protected-branch> && git commit`), then finalize (mark ready for
+   review) — the commit reaches its final shape here, and CI gates on the PR being exactly one
+   commit with a Conventional-Commit subject — the two checks rebase-merge relies on, since the
+   host won't rewrite the message the way squash-merge would.
+6. Once green, **rebase-merge**: your single commit lands on <protected-branch> verbatim, and the
    branch auto-deletes. No branch reuse or reset step needed — the next change starts a fresh
    branch off <protected-branch>.
-6. <protected-branch> stays releasable, never committed to directly. Merge method is rebase-merge
+7. <protected-branch> stays releasable, never committed to directly. Merge method is rebase-merge
    only, enforced by the single-commit + Conventional-Commit checks.
 
 ## Working iteratively when you can't self-verify

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -75,9 +75,9 @@ commit; propose the split before committing.
 
 Script-managed sync branches are outside this model: a repo may maintain a long-lived,
 script-owned branch whose rolling **draft** PR accumulates force-pushed syncs until a human
-merges it (e.g. `git memory-pr`'s memory-sync branch, governed by the repo's own ADRs). There,
-draft means "buffer awaiting the human," not "agent still working" — never finalize, squash,
-rebase, or delete such a branch or PR by hand; the owning script is its only writer.
+merges it (governed by the repo's own docs). There, draft means "buffer awaiting the human," not
+"agent still working" — never finalize, squash, rebase, or delete such a branch or PR by hand;
+the owning script is its only writer.
 
 ## Working iteratively when you can't self-verify
 

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -1,7 +1,7 @@
-<!-- Git workflow mechanics, platform-agnostic. Canonical source: my dotfiles.
+<!-- Git workflow mechanics, platform-agnostic. Canonical source: this repo.
      VCS-level only: same on GitHub, GitLab, Bitbucket, or a bare remote. Platform specifics
      (gh/glab, Actions, a host's squash-merge behavior) live in the platform file (github.md).
-     Rationale: claude/README.md. -->
+     Rationale: README.md. -->
 
 > ### GATE
 >
@@ -34,8 +34,8 @@ imperative lowercase subject ≤50 chars (hard limit 72); `type` ∈ feat/fix/do
 test/build/ci/chore; `scope` from this repo's <scopes>. Breaking change: `type!:` or a
 `BREAKING CHANGE:` footer. Blank line, then a body wrapped at 72 explaining _what_ and _why_, never
 _how_. `Co-authored-by:` per human contributor. An agent identity is a first-class git author:
-it goes in the author field (`GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` — ADR-0038 in the dotfiles
-repo), never as a co-author trailer or a tool-credit line in the message. One logical change per
+it goes in the author field (`GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` — carpet-stain/dotfiles
+ADR-0038), never as a co-author trailer or a tool-credit line in the message. One logical change per
 commit; propose the split before committing.
 
 ## Version Control Discipline

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -61,7 +61,12 @@ commit; propose the split before committing.
    (`git reset --soft origin/<protected-branch> && git commit`), then finalize (mark ready for
    review) — the commit reaches its final shape here, and CI gates on the PR being exactly one
    commit with a Conventional-Commit subject — the two checks rebase-merge relies on, since the
-   host won't rewrite the message the way squash-merge would.
+   host won't rewrite the message the way squash-merge would. Finalizing also means rewriting the
+   PR body to stand alone: what changed and why, deviations from any prior plan, verification
+   done — a reviewer derives the whole change from a one-minute read of the top post, no thread
+   required. Comments stay the real-time journal from step 2, useful depth on demand, never
+   required reading — the same terse-PR/verbose-issue split as the tracked issue itself: detail
+   belongs there, before implementation, not in PR prose or code comments.
 6. Once green, **rebase-merge**: your single commit lands on <protected-branch> verbatim, and the
    branch auto-deletes. No branch reuse or reset step needed — the next change starts a fresh
    branch off <protected-branch>.

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -33,7 +33,9 @@ the repo. "PR" means a pull or merge request, whichever your host calls it.
 imperative lowercase subject ≤50 chars (hard limit 72); `type` ∈ feat/fix/docs/style/refactor/perf/
 test/build/ci/chore; `scope` from this repo's <scopes>. Breaking change: `type!:` or a
 `BREAKING CHANGE:` footer. Blank line, then a body wrapped at 72 explaining _what_ and _why_, never
-_how_. `Co-authored-by:` per human contributor; never AI attribution. One logical change per
+_how_. `Co-authored-by:` per human contributor. An agent identity is a first-class git author:
+it goes in the author field (`GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` — ADR-0038 in the dotfiles
+repo), never as a co-author trailer or a tool-credit line in the message. One logical change per
 commit; propose the split before committing.
 
 ## Version Control Discipline

--- a/rules/tools/git.md
+++ b/rules/tools/git.md
@@ -68,6 +68,12 @@ commit; propose the split before committing.
 7. <protected-branch> stays releasable, never committed to directly. Merge method is rebase-merge
    only, enforced by the single-commit + Conventional-Commit checks.
 
+Script-managed sync branches are outside this model: a repo may maintain a long-lived,
+script-owned branch whose rolling **draft** PR accumulates force-pushed syncs until a human
+merges it (e.g. `git memory-pr`'s memory-sync branch, governed by the repo's own ADRs). There,
+draft means "buffer awaiting the human," not "agent still working" — never finalize, squash,
+rebase, or delete such a branch or PR by hand; the owning script is its only writer.
+
 ## Working iteratively when you can't self-verify
 
 Open-PR-early (step 2) still applies here — the draft PR opens at the first commit regardless of

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -48,3 +48,28 @@ co-locate a `README.md` for a deeper guide and point `doc.go` at it — design-p
 & Files rule (no dumping-ground files) applies here too. For relational navigation — callers of a
 symbol, implementers of an interface, rename safety — prefer gopls over grep; grep is for
 text/config/log scans.
+
+## Application structure (layered apps)
+
+Go-concrete realization of `architecture.md`'s layer-boundary principles, scoped to the
+services/CLIs its GATE covers — worked exemplar: Ben Johnson's WTF Dial
+(`github.com/benbjohnson/wtf`, gobeyond.dev's "Standard Package Layout" / "Packages as layers, not
+groups" / "Failure Is Your Domain"). Skip the ceremony for a small CLI with no real dependency
+boundary (design-principles.md: no abstraction without a real boundary).
+
+- **Root package is the domain**, importing nothing implementation-specific: types plus service
+  interfaces (`wtf.DialService`) defined where they're consumed, not where they're implemented —
+  Go's shape for Compose at the edge.
+- **Subpackages wrap one external dependency each**, not a technical layer — `http/`, `sqlite/`,
+  `mock/`, never `models/`/`controllers/`/`services/`. They import the domain package, never each
+  other — Go's shape for Organize by dependency, not technical layer.
+- **`cmd/<bin>/main.go` is the composition root**: a thin `main()` traps signals/exit; a `Main`
+  struct wires concrete implementations (e.g. `sqlite` + `http`) into the domain interfaces —
+  runtime selection at the top, per Compose at the edge. Separate binaries (`cmd/wtfd`, `cmd/wtf`)
+  wire different subsets of the same domain; `mock/` wires a fake subset for tests.
+- **Domain error type**: `Error{Code, Message}` with a sentinel `Code` set (`ENOTFOUND`,
+  `ECONFLICT`, `EINVALID`, `EINTERNAL`, ...) and `ErrorCode(err)`/`ErrorMessage(err)` helpers that
+  unwrap wrapped errors, falling back to `EINTERNAL`/a generic message outside the domain — a
+  transport layer translates `Code` to its own status, keeping that translation at the boundary
+  per Backend quirks stay at the boundary. Extends this file's error-checking guidance with error
+  _design_.

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -4,67 +4,44 @@ paths:
   - "**/*.go"
 ---
 
-<!-- Go idioms. Canonical source: my dotfiles.
-     Language-level only: never any repo path, service name, or branch name here.
-     The paths: frontmatter above is a native Claude Code mechanism: this file only
-     enters context when go.mod or a *.go file is actually touched, in any repo —
-     no prose guard needed to gate on go.mod presence, Claude Code enforces that
-     structurally. Unlike the universal/ files and github.md (always loaded,
-     self-gated by prose), this file has a crisp file-based signal to hook into. -->
+<!-- Go idioms. Canonical source: my dotfiles. Language-level only — never a repo path,
+     service name, or branch name. The paths: frontmatter is the gate: Claude Code loads this
+     only when a go.mod/*.go file is read, structurally, no prose guard needed.
+     Rationale: claude/README.md. -->
 
 > ### GATE
-> Handled by the `paths:` frontmatter above, not prose: this file loads only when Claude
-> reads a Go file (`go.mod`/`*.go`), in any repo. The frontmatter is the gate — no prose
-> guard needed.
+> The `paths:` frontmatter is the gate — this file loads only when Claude reads a Go file
+> (`go.mod`/`*.go`), in any repo. No prose guard needed.
 
 > ### LOCAL-WINS
-> If this repo already has its own Go standards doc (e.g. docs/CODING.md), that doc is
-> AUTHORITATIVE: treat this as baseline only and prefer the repo's doc on conflict.
+> If this repo has its own Go standards doc (e.g. docs/CODING.md), that doc is AUTHORITATIVE:
+> treat this as baseline and prefer the repo's doc on conflict.
 
-> ### COMPOSE — how to give a repo its own concrete Go doc
-> Trigger: only when the human asks to scaffold/adopt conventions, OR a Go repo has no
-> Go standards doc and one is warranted. Default to PROPOSE, don't create — suggest the
-> doc and wait for approval before writing committed files.
-> Steps:
->   1. Read this once as the baseline.
->   2. Write a repo-local doc (e.g. docs/CODING.md) that RESTATES these principles with
->      the repo's CONCRETE nouns: its actual linters + config file, its module layout,
->      its pinned tool versions, its file-naming in practice. Keep the principle, replace
->      the abstraction with the specific.
->   3. Wire the gate so local wins: add to the repo's committed AGENTS.md:
->        "docs/CODING.md is authoritative for Go specifics; treat any generic Go
->         conventions as baseline and prefer this repo's doc on conflict."
->      (This line names NO personal path — commit-safe, true for any contributor.)
->   4. After this, the repo reads its own doc; do not re-distill this for that repo.
+> ### COMPOSE — give a repo its own concrete Go doc
+> Trigger: the human asks to scaffold, OR a Go repo lacks a standards doc and one is warranted.
+> PROPOSE, don't create. Steps: (1) read this as baseline; (2) write a repo-local doc (e.g.
+> docs/CODING.md) restating these with the repo's concrete nouns — its linters + config file,
+> module layout, pinned tool versions, file-naming; (3) add to the repo's AGENTS.md that
+> docs/CODING.md is authoritative over generic Go conventions (name no personal path); (4) after
+> this the repo reads its own doc — don't re-distill.
 
 # Go Conventions
 
-Baseline is **Effective Go** (https://go.dev/doc/effective_go): gofmt formatting (tabs, no manual
-alignment); short lower-case single-word package names (no under_scores, no mixedCaps);
-`MixedCaps`/`mixedCaps` for multiword names; getters without a `Get` prefix; `-er` names for
-one-method interfaces; short receiver names; early-return control flow that omits the unnecessary
-`else`; error strings that identify their origin (lower-case, no trailing punctuation); always
-checking returned errors (never discarding a failure with `_`); doc comments on exported
-identifiers; idiomatic interfaces, slices/maps, `defer`, and the comma-ok idiom.
+Baseline is **Effective Go** (https://go.dev/doc/effective_go): gofmt formatting; short lower-case
+single-word package names; `MixedCaps`/`mixedCaps` for multiword names; getters without a `Get`
+prefix; `-er` names for one-method interfaces; short receiver names; early-return flow that omits
+the needless `else`; error strings that identify their origin (lower-case, no trailing
+punctuation); always check returned errors (never `_`-discard a failure); doc comments on exported
+identifiers. Complement it with modern Go it predates: generics where they clarify,
+`errors.Is`/`errors.As`, the `slices`/`maps` stdlib, module-aware layout.
 
-Effective Go predates generics and modules — treat it as the idiom baseline and complement it with
-modern Go: generics where they clarify, `errors.Is`/`errors.As`, the `slices`/`maps` stdlib, and
-module-aware layout. All consistent with its spirit.
+Make the mechanizable parts tooling-enforced: `gofmt`/`gofumpt` + `goimports` for
+formatting/imports, `golangci-lint` for lintable rules (staticcheck, errcheck, errorlint, revive
+for naming/indent-error-flow and initialism casing, exported-identifier doc comments). Judgment
+parts — package purpose, comment quality, interface design — stay a matter of review.
 
-Make the mechanizable parts tooling-enforced rather than left to convention:
-`gofmt`/`gofumpt` and `goimports` for formatting/imports, and `golangci-lint` for the lintable rules
-(staticcheck including error-string style, errcheck for unchecked errors, errorlint, revive for
-naming/indent-error-flow and initialism casing, package doc comments, and a meaningful doc comment on
-every exported identifier). Judgment parts — package purpose, comment quality, interface design —
-stay a matter of review.
-
-File naming: keep files topical (`inventory.go`, `errors.go`, `logging.go`), avoid dumping-ground
-names (`utils.go`, `helpers.go`, `misc.go`, `common.go`).
-
-Package docs: give every package a `doc.go` with a concise overview (what it owns, primary
-invariants, start-here files) that surfaces in `go doc` and IDE hovers. When a package needs a deeper
-guide, put a co-located `README.md` next to the code and have `doc.go` point to it.
-
-For relational code navigation — who calls this exact symbol, what implements this interface, is a
-rename safe — prefer a language-server-backed tool (gopls) over grep; grep matches text and yields
-false positives on symbol queries. Keep grep for fast text/config/log scans.
+Keep files topical (`inventory.go`, `errors.go`), not dumping grounds (`utils.go`, `helpers.go`).
+Give every package a `doc.go` overview (what it owns, primary invariants, start-here files);
+co-locate a `README.md` for a deeper guide and point `doc.go` at it. For relational navigation —
+callers of a symbol, implementers of an interface, rename safety — prefer gopls over grep; grep is
+for text/config/log scans.

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -43,8 +43,8 @@ formatting/imports, `golangci-lint` for lintable rules (staticcheck, errcheck, e
 for naming/indent-error-flow and initialism casing, exported-identifier doc comments). Judgment
 parts — package purpose, comment quality, interface design — stay a matter of review.
 
-Keep files topical (`inventory.go`, `errors.go`), not dumping grounds (`utils.go`, `helpers.go`).
 Give every package a `doc.go` overview (what it owns, primary invariants, start-here files);
-co-locate a `README.md` for a deeper guide and point `doc.go` at it. For relational navigation —
-callers of a symbol, implementers of an interface, rename safety — prefer gopls over grep; grep is
-for text/config/log scans.
+co-locate a `README.md` for a deeper guide and point `doc.go` at it — design-principles.md's Naming
+& Files rule (no dumping-ground files) applies here too. For relational navigation — callers of a
+symbol, implementers of an interface, rename safety — prefer gopls over grep; grep is for
+text/config/log scans.

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -30,18 +30,40 @@ paths:
 
 # Go Conventions
 
-Baseline is [**Effective Go**](https://go.dev/doc/effective_go): gofmt formatting; short lower-case
-single-word package names; `MixedCaps`/`mixedCaps` for multiword names; getters without a `Get`
-prefix; `-er` names for one-method interfaces; short receiver names; early-return flow that omits
-the needless `else`; error strings that identify their origin (lower-case, no trailing
-punctuation); always check returned errors (never `_`-discard a failure); doc comments on exported
-identifiers. Complement it with modern Go it predates: generics where they clarify,
-`errors.Is`/`errors.As`, the `slices`/`maps` stdlib, module-aware layout.
+Baseline is [**Effective Go**](https://go.dev/doc/effective_go), still canonical for core idiom but
+frozen by its own disclaimer (written for the 2009 release; no generics, modules, or newer
+libraries) — so treat it as baseline, not the whole story. Idiom essentials: gofmt formatting;
+short lower-case single-word package names; `MixedCaps`/`mixedCaps` for multiword names; getters
+without a `Get` prefix; `-er` names for one-method interfaces; short receiver names; early-return
+flow that omits the needless `else`; error strings that identify their origin (lower-case, no
+trailing punctuation); always check returned errors (never `_`-discard a failure); doc comments on
+exported identifiers. Supplement Effective Go with the active layer that postdates it: the Go team's
+[Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) (self-described supplement), the
+[Google Go Style Guide](https://google.github.io/styleguide/go/) (clarity > simplicity > concision >
+maintainability > consistency, in that order — Google-scoped, adopt pragmatically), and the values
+layer, Dave Cheney's [Zen of Go](https://dave.cheney.net/2020/02/23/the-zen-of-go) and Rob Pike's
+[Go Proverbs](https://go-proverbs.github.io/).
+
+Design stance: **accept interfaces, return structs** — interfaces belong in the package that
+_consumes_ them (defined where used, not where implemented), implementations return concrete types,
+and defining an interface on the implementor side "for mocking" is an anti-pattern (test through the
+real implementation's public API). Generics follow "write code, not types": reach for a type
+parameter only when you're about to duplicate code that differs solely by type; if you only call a
+method, use an interface, not a type parameter. Context is passed explicitly as the first parameter,
+never stored in a struct field. Errors are values, handled explicitly at the point of failure: wrap
+with `%w`, inspect with `errors.Is`/`errors.As`/`errors.Join`; packages return root error values
+and wrapping is an application-level policy, not a library one.
 
 Make the mechanizable parts tooling-enforced: `gofmt`/`gofumpt` + `goimports` for
-formatting/imports, `golangci-lint` for lintable rules (staticcheck, errcheck, errorlint, revive
-for naming/indent-error-flow and initialism casing, exported-identifier doc comments). Judgment
-parts — package purpose, comment quality, interface design — stay a matter of review.
+formatting/imports, `golangci-lint` (v2: `linters` and `formatters` are separate config sections;
+the `staticcheck` linter now subsumes gosimple + stylecheck) for lintable rules — staticcheck,
+errcheck, errorlint, revive for naming/indent-error-flow and initialism casing, exported-identifier
+doc comments. Pin dev tools with the go.mod `tool` directive (`go get -tool` / `go tool`, Go 1.24+),
+not a `tools.go` hack. Run `govulncheck` in CI — its reachability analysis flags only vulnerabilities
+on live call paths, the Go-concrete realization of engineering-practices.md's Security By Default.
+Test table-driven with `testdata`/txtar cases before reaching for testify; `testing/synctest`
+(stable in 1.25) for deterministic concurrency tests. Judgment parts — package purpose, comment
+quality, interface design — stay a matter of review.
 
 Give every package a `doc.go` overview (what it owns, primary invariants, start-here files);
 co-locate a `README.md` for a deeper guide and point `doc.go` at it — design-principles.md's Naming
@@ -49,27 +71,53 @@ co-locate a `README.md` for a deeper guide and point `doc.go` at it — design-p
 symbol, implementers of an interface, rename safety — prefer gopls over grep; grep is for
 text/config/log scans.
 
+## Dependency posture — Go is stdlib-first
+
+The mirror image of Python's reach-for-a-library default: in Go the standard library _is_ the
+default, and "a little copying is better than a little dependency" (Proverb) is real guidance, not
+asceticism. Reach for the stdlib where the ecosystem once reached for a package: `log/slog` for
+structured logging (Go 1.21 — the default for new code, not a reason to rip out zap), `net/http`
+routing (method+wildcard patterns, Go 1.22), `errors.Join` over a wrapping library, `testing`
+table-driven over a framework. Add a dependency when it earns its keep — a hard problem (a database
+driver, a TUI runtime), a genuine boundary — not to avoid boilerplate you could copy in ten lines.
+Same standing filter as Python from the other side: prefer the boring, well-owned choice, keep the
+skepticism for speculative or single-maintainer deps — Simplicity First cuts both ways.
+
 ## Application structure (layered apps)
 
 Go-concrete realization of `architecture.md`'s layer-boundary principles, scoped to the
 services/CLIs its GATE covers — worked exemplar: Ben Johnson's WTF Dial
 (`github.com/benbjohnson/wtf`, gobeyond.dev's "Standard Package Layout" / "Packages as layers, not
-groups" / "Failure Is Your Domain"). Skip the ceremony for a small CLI with no real dependency
-boundary (design-principles.md: no abstraction without a real boundary).
+groups" / "Failure Is Your Domain"). Start flat and grow into it: the official
+[layout guidance](https://go.dev/doc/modules/layout) is `go.mod` + files in the root, splitting into
+packages only when size warrants — a directory _is_ a package, so don't add one just to sort files,
+and big packages/files aren't anti-patterns. Don't cargo-cult `golang-standards/project-layout`
+(`pkg/`, `api/`, ...) — Russ Cox has disavowed it as non-standard. Skip the ceremony entirely for a
+small CLI with no real dependency boundary (design-principles.md: no abstraction without a real
+boundary).
 
 - **Root package is the domain**, importing nothing implementation-specific: types plus service
   interfaces (`wtf.DialService`) defined where they're consumed, not where they're implemented —
   Go's shape for Compose at the edge.
 - **Subpackages wrap one external dependency each**, not a technical layer — `http/`, `sqlite/`,
   `mock/`, never `models/`/`controllers/`/`services/`. They import the domain package, never each
-  other — Go's shape for Organize by dependency, not technical layer.
+  other — Go's shape for Organize by dependency, not technical layer; the domain-over-layer split
+  everyone now converges on (`internal/user`, not `internal/handlers`). Push supporting packages
+  into `internal/` (compiler-enforced privacy) so their APIs stay refactorable; a server's logic
+  belongs there, since a server exports nothing.
 - **`cmd/<bin>/main.go` is the composition root**: a thin `main()` traps signals/exit; a `Main`
   struct wires concrete implementations (e.g. `sqlite` + `http`) into the domain interfaces —
-  runtime selection at the top, per Compose at the edge. Separate binaries (`cmd/wtfd`, `cmd/wtf`)
-  wire different subsets of the same domain; `mock/` wires a fake subset for tests.
+  runtime selection at the top, per Compose at the edge, manual wiring over a DI framework. Separate
+  binaries (`cmd/wtfd`, `cmd/wtf`) wire different subsets of the same domain; `mock/` wires a fake
+  subset for tests.
 - **Domain error type**: `Error{Code, Message}` with a sentinel `Code` set (`ENOTFOUND`,
   `ECONFLICT`, `EINVALID`, `EINTERNAL`, ...) and `ErrorCode(err)`/`ErrorMessage(err)` helpers that
   unwrap wrapped errors, falling back to `EINTERNAL`/a generic message outside the domain — a
   transport layer translates `Code` to its own status, keeping that translation at the boundary
   per Backend quirks stay at the boundary. Extends this file's error-checking guidance with error
   _design_.
+
+To _read_ for idiomatic Go: the standard library first (net/http, net, crypto/subtle — nothing
+there by accident), then BoltDB, groupcache/singleflight, Caddy, go-kit, and WTF Dial itself. Study
+Kubernetes for scale, but the community consensus is not to emulate its style (over-abstraction, a
+`utils` package, import renaming) — calibrate "idiomatic" against the stdlib, not the big names.

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -10,14 +10,17 @@ paths:
      Rationale: claude/README.md. -->
 
 > ### GATE
+>
 > The `paths:` frontmatter is the gate — this file loads only when Claude reads a Go file
 > (`go.mod`/`*.go`), in any repo. No prose guard needed.
 
 > ### LOCAL-WINS
+>
 > If this repo has its own Go standards doc (e.g. docs/CODING.md), that doc is AUTHORITATIVE:
 > treat this as baseline and prefer the repo's doc on conflict.
 
 > ### COMPOSE — give a repo its own concrete Go doc
+>
 > Trigger: the human asks to scaffold, OR a Go repo lacks a standards doc and one is warranted.
 > PROPOSE, don't create. Steps: (1) read this as baseline; (2) write a repo-local doc (e.g.
 > docs/CODING.md) restating these with the repo's concrete nouns — its linters + config file,
@@ -27,7 +30,7 @@ paths:
 
 # Go Conventions
 
-Baseline is **Effective Go** (https://go.dev/doc/effective_go): gofmt formatting; short lower-case
+Baseline is [**Effective Go**](https://go.dev/doc/effective_go): gofmt formatting; short lower-case
 single-word package names; `MixedCaps`/`mixedCaps` for multiword names; getters without a `Get`
 prefix; `-er` names for one-method interfaces; short receiver names; early-return flow that omits
 the needless `else`; error strings that identify their origin (lower-case, no trailing

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -1,0 +1,70 @@
+---
+paths:
+  - "go.mod"
+  - "**/*.go"
+---
+
+<!-- Go idioms. Canonical source: my dotfiles.
+     Language-level only: never any repo path, service name, or branch name here.
+     The paths: frontmatter above is a native Claude Code mechanism: this file only
+     enters context when go.mod or a *.go file is actually touched, in any repo —
+     no prose guard needed to gate on go.mod presence, Claude Code enforces that
+     structurally. Unlike the universal/ files and github.md (always loaded,
+     self-gated by prose), this file has a crisp file-based signal to hook into. -->
+
+> ### GATE
+> Handled by the `paths:` frontmatter above, not prose: this file loads only when Claude
+> reads a Go file (`go.mod`/`*.go`), in any repo. The frontmatter is the gate — no prose
+> guard needed.
+
+> ### LOCAL-WINS
+> If this repo already has its own Go standards doc (e.g. docs/CODING.md), that doc is
+> AUTHORITATIVE: treat this as baseline only and prefer the repo's doc on conflict.
+
+> ### COMPOSE — how to give a repo its own concrete Go doc
+> Trigger: only when the human asks to scaffold/adopt conventions, OR a Go repo has no
+> Go standards doc and one is warranted. Default to PROPOSE, don't create — suggest the
+> doc and wait for approval before writing committed files.
+> Steps:
+>   1. Read this once as the baseline.
+>   2. Write a repo-local doc (e.g. docs/CODING.md) that RESTATES these principles with
+>      the repo's CONCRETE nouns: its actual linters + config file, its module layout,
+>      its pinned tool versions, its file-naming in practice. Keep the principle, replace
+>      the abstraction with the specific.
+>   3. Wire the gate so local wins: add to the repo's committed AGENTS.md:
+>        "docs/CODING.md is authoritative for Go specifics; treat any generic Go
+>         conventions as baseline and prefer this repo's doc on conflict."
+>      (This line names NO personal path — commit-safe, true for any contributor.)
+>   4. After this, the repo reads its own doc; do not re-distill this for that repo.
+
+# Go Conventions
+
+Baseline is **Effective Go** (https://go.dev/doc/effective_go): gofmt formatting (tabs, no manual
+alignment); short lower-case single-word package names (no under_scores, no mixedCaps);
+`MixedCaps`/`mixedCaps` for multiword names; getters without a `Get` prefix; `-er` names for
+one-method interfaces; short receiver names; early-return control flow that omits the unnecessary
+`else`; error strings that identify their origin (lower-case, no trailing punctuation); always
+checking returned errors (never discarding a failure with `_`); doc comments on exported
+identifiers; idiomatic interfaces, slices/maps, `defer`, and the comma-ok idiom.
+
+Effective Go predates generics and modules — treat it as the idiom baseline and complement it with
+modern Go: generics where they clarify, `errors.Is`/`errors.As`, the `slices`/`maps` stdlib, and
+module-aware layout. All consistent with its spirit.
+
+Make the mechanizable parts tooling-enforced rather than left to convention:
+`gofmt`/`gofumpt` and `goimports` for formatting/imports, and `golangci-lint` for the lintable rules
+(staticcheck including error-string style, errcheck for unchecked errors, errorlint, revive for
+naming/indent-error-flow and initialism casing, package doc comments, and a meaningful doc comment on
+every exported identifier). Judgment parts — package purpose, comment quality, interface design —
+stay a matter of review.
+
+File naming: keep files topical (`inventory.go`, `errors.go`, `logging.go`), avoid dumping-ground
+names (`utils.go`, `helpers.go`, `misc.go`, `common.go`).
+
+Package docs: give every package a `doc.go` with a concise overview (what it owns, primary
+invariants, start-here files) that surfaces in `go doc` and IDE hovers. When a package needs a deeper
+guide, put a co-located `README.md` next to the code and have `doc.go` point to it.
+
+For relational code navigation — who calls this exact symbol, what implements this interface, is a
+rename safe — prefer a language-server-backed tool (gopls) over grep; grep matches text and yields
+false positives on symbol queries. Keep grep for fast text/config/log scans.

--- a/rules/tools/go.md
+++ b/rules/tools/go.md
@@ -4,10 +4,10 @@ paths:
   - "**/*.go"
 ---
 
-<!-- Go idioms. Canonical source: my dotfiles. Language-level only — never a repo path,
+<!-- Go idioms. Canonical source: this repo. Language-level only — never a repo path,
      service name, or branch name. The paths: frontmatter is the gate: Claude Code loads this
      only when a go.mod/*.go file is read, structurally, no prose guard needed.
-     Rationale: claude/README.md. -->
+     Rationale: README.md. -->
 
 > ### GATE
 >

--- a/rules/tools/python.md
+++ b/rules/tools/python.md
@@ -1,0 +1,88 @@
+---
+paths:
+  - "pyproject.toml"
+  - "**/*.py"
+---
+
+<!-- Python idioms. Canonical source: my dotfiles. Language-level only — never a repo path,
+     service name, or branch name. The paths: frontmatter is the gate: Claude Code loads this
+     only when a pyproject.toml/*.py file is read, structurally, no prose guard needed.
+     Rationale: claude/README.md. -->
+
+> ### GATE
+>
+> The `paths:` frontmatter is the gate — this file loads only when Claude reads a Python file
+> (`pyproject.toml`/`*.py`), in any repo. No prose guard needed.
+
+> ### LOCAL-WINS
+>
+> If this repo has its own Python standards doc (e.g. docs/CODING.md), that doc is AUTHORITATIVE:
+> treat this as baseline and prefer the repo's doc on conflict.
+
+> ### COMPOSE — give a repo its own concrete Python doc
+>
+> Trigger: the human asks to scaffold, OR a Python repo lacks a standards doc and one is
+> warranted. PROPOSE, don't create. Steps: (1) read this as baseline; (2) write a repo-local doc
+> (e.g. docs/CODING.md) restating these with the repo's concrete nouns — its linter/type-checker
+> config, package layout, pinned tool versions, framework stance; (3) add to the repo's AGENTS.md
+> that docs/CODING.md is authoritative over generic Python conventions (name no personal path);
+> (4) after this the repo reads its own doc — don't re-distill.
+
+# Python Conventions
+
+Baseline is [**Effective Python**, 3rd ed.](https://effectivepython.com/) (Slatkin) for idiom,
+with PEP 8 as surface style — enforced by tooling, not litigated in review (PEP 8 itself cedes to
+project guides; don't cite it beyond what ruff enforces). Idiom essentials: `snake_case`
+functions/variables, `PascalCase` classes, `UPPER_CASE` constants, one leading underscore for
+internal names; early-return flow; f-strings; `pathlib` over `os.path`; `enum` over loose
+string/int constants; comprehensions where they clarify, loops where they don't; speak the data
+model (`__iter__`, `__enter__`, ...) instead of inventing bespoke method names; docstrings on
+public API. Type hints throughout, checked strictly — they are contracts, not decoration.
+
+Design stance (Hynek Schlawack's subclassing essays/PyCon talks are the canonical source):
+composition over inheritance for code sharing; `typing.Protocol` over ABCs for interfaces —
+structural, so implementations need not know the interface exists, and defined where consumed,
+exactly like a Go interface. Subclass only where Go would embed: pure specialization that adds
+behavior without modifying the parent's. Exceptions are the error channel — design a small domain
+exception hierarchy and translate it at the boundary; don't import result-type ceremony.
+
+Make the mechanizable parts tooling-enforced: uv for env/packaging/lock (pyproject.toml is the
+one config home, `[dependency-groups]` for dev deps), ruff for lint+format, a strict type checker
+(pyright today; the Rust checkers ty/pyrefly are still settling), pytest (plus hypothesis where
+properties beat examples). `src/` layout, so tests import the installed package, not the working
+copy. Judgment parts — API design, naming, docstring quality — stay a matter of review.
+
+## Dependency posture — Python is not stdlib-maximalist
+
+Go's stdlib-first instinct doesn't transfer. Idiomatic Python reaches for the community-standard
+library where the stdlib equivalent is a known boilerplate pit: httpx/requests over urllib,
+pytest over unittest, click/typer over argparse for real CLIs, structlog over logging plumbing,
+attrs where dataclasses run out. Hand-rolling those to "avoid a dependency" reads as unidiomatic,
+not disciplined. The filter is standing, not novelty: prefer the boring, widely adopted choice,
+and keep the usual skepticism for single-maintainer micro-deps and frameworks for one call site —
+Simplicity First still applies; liberal is not indiscriminate.
+
+## Application structure (layered apps)
+
+Python-concrete realization of `architecture.md`'s layer-boundary principles — reference text:
+[Architecture Patterns with Python](https://www.cosmicpython.com/) (Percival & Gregory), read
+WITH its own caveats: the authors document ("So Many Layers!") that the full stack — repository,
+unit of work, message bus, CQRS — is overkill for most apps. Apply per module where domain logic
+is real; a CRUD module stays plain. Opinionated frameworks invert this: inside Django, work
+framework-native — fat models as the internal API, `transaction.atomic` as the unit of work —
+rather than wrapping the ORM in repositories you then maintain forever (James Bennett's "against
+service layers").
+
+- **Domain modules hold plain classes** — dataclasses/attrs with behavior, importing nothing
+  transport- or IO-specific. Pydantic belongs at untrusted-data edges (request bodies, config),
+  never as the domain model — validation is a boundary concern.
+- **One thin facade module per external dependency**, owned by you, wrapping its client library —
+  the same move as Go's one-package-per-dependency, and the precondition for "don't mock what
+  you don't own": tests fake your facade, never the third-party API.
+- **Interfaces live with their consumers** as `Protocol`s; concrete adapters import the domain,
+  never each other.
+- **A composition root wires it**: an app factory / `main()` / `bootstrap.py` passing
+  dependencies as plain constructor/function arguments. No DI framework, no globals discovered
+  at depth.
+- **Domain exceptions translate at the boundary**: transport code maps the domain hierarchy to
+  status/exit codes; deeper layers raise domain errors and never speak HTTP.

--- a/rules/tools/python.md
+++ b/rules/tools/python.md
@@ -4,10 +4,10 @@ paths:
   - "**/*.py"
 ---
 
-<!-- Python idioms. Canonical source: my dotfiles. Language-level only — never a repo path,
+<!-- Python idioms. Canonical source: this repo. Language-level only — never a repo path,
      service name, or branch name. The paths: frontmatter is the gate: Claude Code loads this
      only when a pyproject.toml/*.py file is read, structurally, no prose guard needed.
-     Rationale: claude/README.md. -->
+     Rationale: README.md. -->
 
 > ### GATE
 >

--- a/rules/tools/terraform.md
+++ b/rules/tools/terraform.md
@@ -1,0 +1,115 @@
+---
+paths:
+  - "**/*.tf"
+  - "**/*.tofu"
+  - "**/*.tfvars"
+  - "**/*.tftest.hcl"
+  - "**/.terraform.lock.hcl"
+---
+
+<!-- Terraform/OpenTofu idioms. Canonical source: my dotfiles. Language-level only — never a
+     repo path, state bucket, org name, or branch. The paths: frontmatter is the gate: Claude
+     Code loads this only when a TF file is read, structurally, no prose guard needed.
+     Rationale: claude/README.md. -->
+
+> ### GATE
+>
+> The `paths:` frontmatter is the gate — this file loads only when Claude reads a
+> Terraform/OpenTofu file (`*.tf`/`*.tofu`/`*.tfvars`/tests/lockfile), in any repo. No prose
+> guard needed.
+
+> ### LOCAL-WINS
+>
+> If this repo has its own Terraform standards doc (e.g. docs/CODING.md), that doc is
+> AUTHORITATIVE: treat this as baseline and prefer the repo's doc on conflict.
+
+> ### COMPOSE — give a repo its own concrete Terraform doc
+>
+> Trigger: the human asks to scaffold, OR a TF repo lacks a standards doc and one is warranted.
+> PROPOSE, don't create. Steps: (1) read this as baseline; (2) write a repo-local doc (e.g.
+> docs/CODING.md) restating these with the repo's concrete nouns — tofu or terraform, the
+> backend and how its state is encrypted, provider pins, linter/scanner config, module layout;
+> (3) add to the repo's AGENTS.md that docs/CODING.md is authoritative over generic Terraform
+> conventions (name no personal path); (4) after this the repo reads its own doc — don't
+> re-distill.
+
+# Terraform / OpenTofu Conventions
+
+Baseline is the [OpenTofu style conventions](https://opentofu.org/docs/language/syntax/style/)
+(mirroring HashiCorp's style guide), with
+[Terraform: Up & Running](https://www.terraformupandrunning.com/) (Brikman, 3rd ed.) as the
+idiom text — it predates the OpenTofu split; the mechanics transfer. Essentials: `fmt`
+formatting is non-negotiable; `snake_case` names; name a resource for its role, never its type
+(`github_repository.this`, not `.github_repo` — the type label already says what it is); `this`
+for the only instance of a type in a module; singular resource names even under `for_each` —
+the map provides the plurality; `locals` for any expression used twice; `for_each` over
+`count` for collections (keyed addresses survive reordering; `count` is for the boolean
+create-or-don't case only). Write `.tf`, not `.tofu`: the surrounding toolchain (tflint,
+terraform-docs) parses only the shared extension, so the fork-specific one buys nothing and
+silently drops files out of lint and docs coverage.
+
+Design stance: **HCL is declarative configuration, not a programming language** — model
+variation as data, not logic. A typed map fed to `for_each` beats chained conditionals,
+nested-splat pyramids, and clever `flatten`/`merge` meta-programming; when an expression needs
+a comment to parse, restructure the data instead. Config-as-data also keeps the change diff
+where review wants it: editing an entry in a map, not editing resource logic. Structure: start
+with a **flat root module** and extract a child module only at a real reuse boundary — a
+module with one caller is abstraction without a boundary (Simplicity First); avoid module
+nesting beyond one level. File layout by concern: `versions.tf` (core + provider
+requirements), `variables.tf`, `main.tf` (splitting by resource area as it grows),
+`outputs.tf`.
+
+Version discipline: `required_version` on the core, `required_providers` with `~>` pessimistic
+pins, and the committed `.terraform.lock.hcl` as the reproducibility gate — upgrades happen
+deliberately via `init -upgrade` in their own diff, never as a side effect. Install and pin
+the runtime itself with [tenv](https://github.com/tofuutils/tenv): it resolves the version
+from the config's own `required_version` constraint (or an `.opentofu-version` file) and
+verifies release signatures — the same honor-the-code's-pin behavior as Go's
+`GOTOOLCHAIN=auto` or uv's pinned interpreters, so the version the config declares is the
+version that runs. Vendor providers with `tofu providers mirror` when an environment needs
+offline or supply-chain-pinned installs.
+
+Interfaces are contracts: every variable and output carries a `type` and `description`;
+`validation` blocks encode constraints the type system can't; `sensitive = true` on anything
+secret-shaped; `nullable = false` unless null is genuinely meaningful. A module's variables
+and outputs are its API — document them as such, and let terraform-docs generate the readable
+reference from those declarations: generated docs are only as good as the types and
+descriptions they're built from.
+
+**State is a plaintext secret store.** Providers write attribute values into it verbatim —
+`github_actions_secret` is the canonical trap: the value is sensitive-_marked_ but not hidden
+from state. So: remote backend with locking; encryption at rest is required, not optional, the
+moment any resource writes a secret into state (OpenTofu's client-side `encryption` block with
+`enforced = true` covers state and plan files; keep key material in the environment, never in
+config). Never commit state, plan files, or `.terraform/` — gitignore all three from day one.
+
+Refactor declaratively: `moved {}`, `removed {}`, and `import {}` blocks (with `for_each` for
+adopting existing infrastructure in one sweep) — all reviewable in the plan before they touch
+anything. `state mv`/`state rm` surgery is the last resort, not the habit.
+
+Make the mechanizable parts tooling-enforced: `fmt -check` and `validate` as the floor,
+`tflint` for lintable rules (the bundled terraform ruleset's `recommended` preset is the
+baseline; note tflint has no official OpenTofu support — fine on `.tf`, broken on `.tofu` and
+some OpenTofu-only syntax), a config security scanner (trivy — the successor to tfsec — or
+checkov) for the misconfiguration classes engineering-practices.md's Security By Default
+names, and native `tofu test` (`.tftest.hcl`) where a module's contract deserves proof.
+Judgment parts — resource naming, module boundaries, what becomes data vs config — stay a
+matter of review.
+
+## OpenTofu-first
+
+Terraform relicensed to BUSL in 2023; OpenTofu is the MPL fork under Linux Foundation
+governance, drop-in for this layer and the provider ecosystem. Default to OpenTofu for new
+work. Know the one-way doors before leaning on divergent features: state written with OpenTofu
+encryption (and state touched by OpenTofu ≥1.10 generally) is not readable by Terraform —
+fine as a deliberate commitment, wrong as an accident. The per-repo tool choice, backend, and
+encryption scheme are repo decisions — record them in the repo's ADR and its COMPOSE'd doc,
+not here.
+
+## DRY without Terragrunt
+
+At single-account/single-environment scale, one configuration with `for_each` over a data map
+_is_ the DRY story — config and code separate cleanly inside one codebase. Terragrunt earns
+its keep orchestrating many state files across environments/accounts with shared remote-state
+wiring; below that scale it's a second codebase layer with no boundary to justify it. Revisit
+at genuine multi-env/multi-account scale, not before.

--- a/rules/tools/terraform.md
+++ b/rules/tools/terraform.md
@@ -7,10 +7,10 @@ paths:
   - "**/.terraform.lock.hcl"
 ---
 
-<!-- Terraform/OpenTofu idioms. Canonical source: my dotfiles. Language-level only — never a
+<!-- Terraform/OpenTofu idioms. Canonical source: this repo. Language-level only — never a
      repo path, state bucket, org name, or branch. The paths: frontmatter is the gate: Claude
      Code loads this only when a TF file is read, structurally, no prose guard needed.
-     Rationale: claude/README.md. -->
+     Rationale: README.md. -->
 
 > ### GATE
 >

--- a/rules/universal/ai-collaboration.md
+++ b/rules/universal/ai-collaboration.md
@@ -4,6 +4,7 @@
      Rationale for the terse style: claude/README.md § Why the rule files are terse. -->
 
 > ### GATE — applies always
+>
 > Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
 
 # AI Collaboration
@@ -12,8 +13,8 @@
 
 Prefer explicit contracts, typed errors, named options, and documented behavior over implicit
 convention. When you learn something a future reader needs — a command, an environment fact, a
-gotcha, the meaning of an output — record it in a durable place, not chat memory. Record *why*,
-not just *what*: a decision without its reason gets re-litigated. If behavior is surprising, fix
+gotcha, the meaning of an output — record it in a durable place, not chat memory. Record _why_,
+not just _what_: a decision without its reason gets re-litigated. If behavior is surprising, fix
 it at the source (a clearer name, a typed error, a regression test), not with a mental note.
 
 ## Verify, Don't Trust

--- a/rules/universal/ai-collaboration.md
+++ b/rules/universal/ai-collaboration.md
@@ -1,0 +1,95 @@
+<!-- Universal AI collaboration guide. Canonical source: my dotfiles.
+     Loaded globally for every project. Language- and platform-agnostic.
+     How the agent operates and works with me, not what the code/output looks like
+     (see design-principles.md, engineering-practices.md, communication.md). -->
+
+> ### GATE — applies always
+> These principles apply in their abstract form everywhere; there are no placeholders
+> to fill and nothing to distill into a repo. Do NOT copy this into repos.
+
+# AI Collaboration
+
+## Be Explicit — Write It Down Over Committing To Memory
+
+Strongly prefer explicitness. Write things down in the project rather than keeping them as tribal
+knowledge, chat memory, or an assumption in someone's head.
+
+- Prefer explicit contracts, typed errors, named options, and documented behavior over implicit
+  convention or "you just have to know."
+- When you learn or decide something a future reader would need again — a command sequence, an
+  environment fact, a gotcha, the meaning of an output — record it in the appropriate durable place
+  rather than relying on memory or a single conversation.
+- Prefer durable artifacts (docs, tests, templates, comments that preserve reasoning) over
+  session-only knowledge.
+- If behavior is surprising, make it explicit at the source: a clearer name, a typed error, a doc
+  note, or a regression test — not a mental note.
+- Do not answer a recurring question the same way twice from memory; put the answer where it will be
+  found next time.
+- Record *why* a decision was made, not just *what* was decided. A choice without its reasoning is
+  tribal knowledge with extra steps — the next person (or agent) re-litigates it from scratch.
+
+## Verify, Don't Trust
+
+When analyzing or summarizing something drawn from a resource (web page, tool call, provided
+document), do not trust a memory or retained summary of it. Retrieve the resource afresh and compare
+it to the summary you are preparing, adversarially: fact-check your own work assuming it contains
+errors and hallucinations until proven otherwise. The same applies to local state: don't assume a
+file, symbol, or config value exists or still looks a certain way — confirm it before acting on it.
+
+## Propose Before Implementing
+
+For opinion or judgment-call work — wording, design choices, naming, anything that encodes a
+subjective stance rather than a mechanical fact — analyze first, surface assumptions and
+ambiguity explicitly instead of silently picking an interpretation, propose a plan, and wait for
+an explicit go-ahead before writing or committing. Purely mechanical work (a migration, a verified
+bugfix, a config correctness fix) doesn't need this — proceed and report, the same way any other
+reviewable change would.
+
+## Match Model And Effort To Task Risk
+
+Not every task deserves the same model or the same effort level. Judgment work — design,
+architecture, code review, anything where being wrong is expensive — gets the more capable model
+and higher effort. Mechanical, bulk, or narrow-and-verifiable work gets a lighter model or lower
+effort; it doesn't need the same depth to get right, and paying for it anyway wastes both time and
+cost.
+
+## Work Through Human Toolchains
+
+Operate through the same interfaces, commands, and guardrails a human contributor on this project
+would use — the build targets, test runners, linters, formatters, hooks, and review flow the project
+already provides. This is a safeguard, not a convenience: an agent's work should be as inspectable,
+reproducible, and revertible as a human's, and confining it to human-facing toolchains is what keeps
+it so.
+
+- Prefer the project's provided entry points (a `make`/task target, a script, a documented command)
+  over hand-rolled substitutes or direct calls that skip what those wrappers set up.
+- Do not invent a private path around a safeguard: no bypassing CI or pre-commit gates, no
+  out-of-band edits that skip the checks a human's change would face, no privileged side channel a
+  human wouldn't have.
+- Keep actions reversible and reviewable. Favor changes a human can inspect as a normal diff and
+  undo with normal tools; avoid irreversible or hard-to-audit operations.
+- If a safeguard is wrong or in the way, surface it and propose changing it — do not route around it
+  silently.
+- Do not self-authorize beyond what a human in the same seat would do; when an action is
+  irreversible or exceeds that scope, stop and involve a human.
+
+## Before Finishing, Ask
+
+One consolidated self-check for the four always-loaded universal files (design, engineering,
+communication, collaboration):
+
+- **Propose & verify:** for judgment work, did I propose and wait rather than implement, and
+  verify assumptions and local state instead of trusting memory?
+- **Right model:** did the task get the model and effort its risk actually calls for?
+- **Security:** did I flag any visible risk (secrets, injection, unsafe input) unprompted?
+- **Ownership & simplicity:** does the change live in the layer that should own it, is each unit
+  doing one job, and could it be simpler — no speculative code, flags, or handling for the
+  impossible?
+- **Naming & config:** is naming semantic rather than shape-based, and is tooling config committed
+  as versioned code, not ambient or personal defaults?
+- **Boundaries:** did any backend-specific behavior leak past its boundary, and are logs
+  diagnostic while user-facing output stays concise?
+- **Tests & docs:** do tests prove the right boundary or invariant, do docs reflect the new
+  behavior, and did I write down what the next reader needs?
+- **Communication:** did I say directly what looked wrong rather than softening it, and does no
+  commit, PR, comment, or doc read like generic AI output or credit an AI tool where it shouldn't?

--- a/rules/universal/ai-collaboration.md
+++ b/rules/universal/ai-collaboration.md
@@ -1,95 +1,53 @@
-<!-- Universal AI collaboration guide. Canonical source: my dotfiles.
-     Loaded globally for every project. Language- and platform-agnostic.
+<!-- Universal AI collaboration guide. Canonical source: my dotfiles. Loaded globally.
      How the agent operates and works with me, not what the code/output looks like
-     (see design-principles.md, engineering-practices.md, communication.md). -->
+     (design-principles.md, engineering-practices.md, communication.md).
+     Rationale for the terse style: claude/README.md § Why the rule files are terse. -->
 
 > ### GATE — applies always
-> These principles apply in their abstract form everywhere; there are no placeholders
-> to fill and nothing to distill into a repo. Do NOT copy this into repos.
+> Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
 
 # AI Collaboration
 
-## Be Explicit — Write It Down Over Committing To Memory
+## Be Explicit — Write It Down Over Memory
 
-Strongly prefer explicitness. Write things down in the project rather than keeping them as tribal
-knowledge, chat memory, or an assumption in someone's head.
-
-- Prefer explicit contracts, typed errors, named options, and documented behavior over implicit
-  convention or "you just have to know."
-- When you learn or decide something a future reader would need again — a command sequence, an
-  environment fact, a gotcha, the meaning of an output — record it in the appropriate durable place
-  rather than relying on memory or a single conversation.
-- Prefer durable artifacts (docs, tests, templates, comments that preserve reasoning) over
-  session-only knowledge.
-- If behavior is surprising, make it explicit at the source: a clearer name, a typed error, a doc
-  note, or a regression test — not a mental note.
-- Do not answer a recurring question the same way twice from memory; put the answer where it will be
-  found next time.
-- Record *why* a decision was made, not just *what* was decided. A choice without its reasoning is
-  tribal knowledge with extra steps — the next person (or agent) re-litigates it from scratch.
+Prefer explicit contracts, typed errors, named options, and documented behavior over implicit
+convention. When you learn something a future reader needs — a command, an environment fact, a
+gotcha, the meaning of an output — record it in a durable place, not chat memory. Record *why*,
+not just *what*: a decision without its reason gets re-litigated. If behavior is surprising, fix
+it at the source (a clearer name, a typed error, a regression test), not with a mental note.
 
 ## Verify, Don't Trust
 
-When analyzing or summarizing something drawn from a resource (web page, tool call, provided
-document), do not trust a memory or retained summary of it. Retrieve the resource afresh and compare
-it to the summary you are preparing, adversarially: fact-check your own work assuming it contains
-errors and hallucinations until proven otherwise. The same applies to local state: don't assume a
-file, symbol, or config value exists or still looks a certain way — confirm it before acting on it.
+Don't trust a memory or summary of a resource — retrieve it fresh and fact-check your own work
+adversarially, assuming errors until proven otherwise. Same for local state: confirm a file,
+symbol, or config value still exists and looks as expected before acting on it.
 
 ## Propose Before Implementing
 
-For opinion or judgment-call work — wording, design choices, naming, anything that encodes a
-subjective stance rather than a mechanical fact — analyze first, surface assumptions and
-ambiguity explicitly instead of silently picking an interpretation, propose a plan, and wait for
-an explicit go-ahead before writing or committing. Purely mechanical work (a migration, a verified
-bugfix, a config correctness fix) doesn't need this — proceed and report, the same way any other
-reviewable change would.
+For judgment work — wording, design, naming, anything encoding a subjective stance — analyze
+first, surface assumptions and ambiguity, propose a plan, and wait for a go-ahead before writing
+or committing. Purely mechanical work (a migration, a verified bugfix, a config fix) doesn't need
+this — proceed and report.
 
 ## Match Model And Effort To Task Risk
 
-Not every task deserves the same model or the same effort level. Judgment work — design,
-architecture, code review, anything where being wrong is expensive — gets the more capable model
-and higher effort. Mechanical, bulk, or narrow-and-verifiable work gets a lighter model or lower
-effort; it doesn't need the same depth to get right, and paying for it anyway wastes both time and
-cost.
+Judgment work where being wrong is expensive gets the more capable model and higher effort.
+Mechanical, bulk, or narrow-and-verifiable work gets a lighter model or lower effort — paying for
+more wastes time and cost.
 
 ## Work Through Human Toolchains
 
-Operate through the same interfaces, commands, and guardrails a human contributor on this project
-would use — the build targets, test runners, linters, formatters, hooks, and review flow the project
-already provides. This is a safeguard, not a convenience: an agent's work should be as inspectable,
-reproducible, and revertible as a human's, and confining it to human-facing toolchains is what keeps
-it so.
-
-- Prefer the project's provided entry points (a `make`/task target, a script, a documented command)
-  over hand-rolled substitutes or direct calls that skip what those wrappers set up.
-- Do not invent a private path around a safeguard: no bypassing CI or pre-commit gates, no
-  out-of-band edits that skip the checks a human's change would face, no privileged side channel a
-  human wouldn't have.
-- Keep actions reversible and reviewable. Favor changes a human can inspect as a normal diff and
-  undo with normal tools; avoid irreversible or hard-to-audit operations.
-- If a safeguard is wrong or in the way, surface it and propose changing it — do not route around it
-  silently.
-- Do not self-authorize beyond what a human in the same seat would do; when an action is
-  irreversible or exceeds that scope, stop and involve a human.
+Operate through the interfaces a human contributor would use — the project's build targets, test
+runners, linters, hooks, and review flow — so the agent's work stays as inspectable, reproducible,
+and revertible as a human's. Don't bypass CI or pre-commit gates, invent a private path around a
+safeguard, or self-authorize beyond what a human in the same seat would do. If a safeguard is
+wrong, surface it and propose changing it — don't route around it silently. When an action is
+irreversible or exceeds that scope, stop and involve a human.
 
 ## Before Finishing, Ask
 
-One consolidated self-check for the four always-loaded universal files (design, engineering,
-communication, collaboration):
-
-- **Propose & verify:** for judgment work, did I propose and wait rather than implement, and
-  verify assumptions and local state instead of trusting memory?
-- **Right model:** did the task get the model and effort its risk actually calls for?
-- **Security:** did I flag any visible risk (secrets, injection, unsafe input) unprompted?
-- **Ownership & simplicity:** does the change live in the layer that should own it, is each unit
-  doing one job, and could it be simpler — no speculative code, flags, or handling for the
-  impossible?
-- **Naming & config:** is naming semantic rather than shape-based, and is tooling config committed
-  as versioned code, not ambient or personal defaults?
-- **Boundaries:** did any backend-specific behavior leak past its boundary, and are logs
-  diagnostic while user-facing output stays concise?
-- **Tests & docs:** do tests prove the right boundary or invariant, do docs reflect the new
-  behavior, and did I write down what the next reader needs?
-- **Communication:** did I say directly what looked wrong rather than softening it, and does no
-  commit, PR, comment, or doc read like generic AI output or credit an AI tool where it shouldn't?
+- **Propose & verify:** proposed and waited on judgment work; verified assumptions and state?
+- **Right model & security:** matched model/effort to risk; flagged visible risks unprompted?
+- **Simplicity & ownership:** simplest form; each unit one job; logic in the layer that owns it?
+- **Tests & docs:** tests prove the right boundary; docs and the next reader's context updated?
+- **Communication:** said what looked wrong directly; nothing reads as generic AI or credits a tool?

--- a/rules/universal/ai-collaboration.md
+++ b/rules/universal/ai-collaboration.md
@@ -23,6 +23,13 @@ Don't trust a memory or summary of a resource — retrieve it fresh and fact-che
 adversarially, assuming errors until proven otherwise. Same for local state: confirm a file,
 symbol, or config value still exists and looks as expected before acting on it.
 
+Before removing or simplifying code that's surprising, load-bearing but unexplained, or
+otherwise looks intentional, recover its intent before treating it as removable — a comment is
+the cheapest source; when that's not enough, the code's own history (blame → commit → PR/issue)
+often holds the _why_ a static read can't. Reach for it deliberately: the trigger is "about to
+delete or simplify something I can't explain," not a blanket habit. Treat it as a strong
+nudge, not a guarantee — no hook can force an agent to check history first.
+
 ## Propose Before Implementing
 
 For judgment work — wording, design, naming, anything encoding a subjective stance — analyze

--- a/rules/universal/ai-collaboration.md
+++ b/rules/universal/ai-collaboration.md
@@ -48,6 +48,6 @@ irreversible or exceeds that scope, stop and involve a human.
 
 - **Propose & verify:** proposed and waited on judgment work; verified assumptions and state?
 - **Right model & security:** matched model/effort to risk; flagged visible risks unprompted?
-- **Simplicity & ownership:** simplest form; each unit one job; logic in the layer that owns it?
+- **Simplicity & ownership:** simplest form; each unit one job; logic living where it belongs?
 - **Tests & docs:** tests prove the right boundary; docs and the next reader's context updated?
 - **Communication:** said what looked wrong directly; nothing reads as generic AI or credits a tool?

--- a/rules/universal/ai-collaboration.md
+++ b/rules/universal/ai-collaboration.md
@@ -1,7 +1,7 @@
-<!-- Universal AI collaboration guide. Canonical source: my dotfiles. Loaded globally.
+<!-- Universal AI collaboration guide. Canonical source: this repo. Loaded globally.
      How the agent operates and works with me, not what the code/output looks like
      (design-principles.md, engineering-practices.md, communication.md).
-     Rationale for the terse style: claude/README.md § Why the rule files are terse. -->
+     Rationale for the terse style: README.md § Why the rule files are terse. -->
 
 > ### GATE — applies always
 >

--- a/rules/universal/communication.md
+++ b/rules/universal/communication.md
@@ -1,34 +1,30 @@
-<!-- Universal communication style. Canonical source: my dotfiles.
-     Loaded globally for every project. Language- and platform-agnostic.
-     What gets said and written, not how the agent operates (see ai-collaboration.md). -->
+<!-- Universal communication style. Canonical source: my dotfiles. Loaded globally.
+     What gets said and written, not how the agent operates (ai-collaboration.md). -->
 
 > ### GATE — applies always
-> These principles apply in their abstract form everywhere; there are no placeholders
-> to fill and nothing to distill into a repo. Do NOT copy this into repos.
+> Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
 
 # Communication
 
 ## Writing Style
 
-Prose in a repo — comments, docs, commit messages, PR descriptions — should read like a person
-wrote it: terse, concrete, plain. Lead with the point; cut filler ("it's worth noting",
-"additionally"), hedging, and puffery. Prefer plain verbs (is, has, uses, runs) over dressed-up
-ones (serves as, leverages, boasts). Name the specific thing — the tool, the file, the reason —
-instead of a generic adjective. Short sentences beat long compound ones; fragments are fine for
-emphasis.
+Prose in a repo — comments, docs, commit messages, PRs — reads like a person wrote it: terse,
+concrete, plain. Lead with the point; cut filler ("it's worth noting"), hedging, and puffery.
+Prefer plain verbs (is, has, uses) over dressed-up ones (serves as, leverages). Name the specific
+thing — the tool, the file, the reason — not a generic adjective. Short sentences beat long
+compound ones; fragments are fine.
 
-Watch for AI-writing tells and cut them on sight: overused words (delve, robust, seamless,
-crucial, testament, tapestry, and similar), filler-verb constructions ("stands as", "marks a
-pivotal moment"), negative parallelism ("not just X but Y"), forced rule-of-three lists, and
-present-participle padding ("further enhancing its significance"). Several of these clustering
-together in one passage is the strongest signal it needs a rewrite.
+Cut AI-writing tells on sight: overused words (delve, robust, seamless, crucial, testament,
+tapestry), filler-verb constructions ("stands as"), negative parallelism ("not just X but Y"),
+forced rule-of-three lists, present-participle padding ("further enhancing its significance").
+Several clustering in one passage is the strongest signal to rewrite.
 
-Never attribute authorship to an AI or assistant tool in repo content — commits, PR
-descriptions, comments, docs. The repo should read as the contributor's own work.
+Never credit an AI or assistant tool in repo content — commits, PRs, comments, docs. The repo
+reads as the contributor's own work.
 
 ## Communication Style
 
-If a plan or piece of code looks wrong, say so up front, with the reason — not buried at the end,
-not softened into a question. Hold that position under pushback until a new fact changes it, not
-until the tone changes. Mark speculation as speculation and distinguish something just read from
-something recalled — don't present either with false certainty.
+If a plan or code looks wrong, say so up front, with the reason — not buried at the end or
+softened into a question. Hold that position under pushback until a new fact changes it, not until
+the tone changes. Mark speculation as speculation; distinguish what you just read from what you
+recall — don't present either with false certainty.

--- a/rules/universal/communication.md
+++ b/rules/universal/communication.md
@@ -1,0 +1,34 @@
+<!-- Universal communication style. Canonical source: my dotfiles.
+     Loaded globally for every project. Language- and platform-agnostic.
+     What gets said and written, not how the agent operates (see ai-collaboration.md). -->
+
+> ### GATE — applies always
+> These principles apply in their abstract form everywhere; there are no placeholders
+> to fill and nothing to distill into a repo. Do NOT copy this into repos.
+
+# Communication
+
+## Writing Style
+
+Prose in a repo — comments, docs, commit messages, PR descriptions — should read like a person
+wrote it: terse, concrete, plain. Lead with the point; cut filler ("it's worth noting",
+"additionally"), hedging, and puffery. Prefer plain verbs (is, has, uses, runs) over dressed-up
+ones (serves as, leverages, boasts). Name the specific thing — the tool, the file, the reason —
+instead of a generic adjective. Short sentences beat long compound ones; fragments are fine for
+emphasis.
+
+Watch for AI-writing tells and cut them on sight: overused words (delve, robust, seamless,
+crucial, testament, tapestry, and similar), filler-verb constructions ("stands as", "marks a
+pivotal moment"), negative parallelism ("not just X but Y"), forced rule-of-three lists, and
+present-participle padding ("further enhancing its significance"). Several of these clustering
+together in one passage is the strongest signal it needs a rewrite.
+
+Never attribute authorship to an AI or assistant tool in repo content — commits, PR
+descriptions, comments, docs. The repo should read as the contributor's own work.
+
+## Communication Style
+
+If a plan or piece of code looks wrong, say so up front, with the reason — not buried at the end,
+not softened into a question. Hold that position under pushback until a new fact changes it, not
+until the tone changes. Mark speculation as speculation and distinguish something just read from
+something recalled — don't present either with false certainty.

--- a/rules/universal/communication.md
+++ b/rules/universal/communication.md
@@ -2,6 +2,7 @@
      What gets said and written, not how the agent operates (ai-collaboration.md). -->
 
 > ### GATE — applies always
+>
 > Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
 
 # Communication

--- a/rules/universal/communication.md
+++ b/rules/universal/communication.md
@@ -1,4 +1,4 @@
-<!-- Universal communication style. Canonical source: my dotfiles. Loaded globally.
+<!-- Universal communication style. Canonical source: this repo. Loaded globally.
      What gets said and written, not how the agent operates (ai-collaboration.md). -->
 
 > ### GATE — applies always

--- a/rules/universal/communication.md
+++ b/rules/universal/communication.md
@@ -23,6 +23,9 @@ Several clustering in one passage is the strongest signal to rewrite.
 Never credit an AI or assistant tool in repo content — commits, PRs, comments, docs. The repo
 reads as the contributor's own work.
 
+GitHub-facing output — issues, PRs, comments, commit bodies — additionally follows `voice.md`;
+this file covers in-session communication with the maintainer only.
+
 ## Communication Style
 
 If a plan or code looks wrong, say so up front, with the reason — not buried at the end or

--- a/rules/universal/communication.md
+++ b/rules/universal/communication.md
@@ -23,10 +23,16 @@ Several clustering in one passage is the strongest signal to rewrite.
 Never credit an AI or assistant tool in repo content — commits, PRs, comments, docs. The repo
 reads as the contributor's own work.
 
-GitHub-facing output — issues, PRs, comments, commit bodies — additionally follows `voice.md`;
-this file covers in-session communication with the maintainer only.
+GitHub-facing output an agent posts as itself — issues, PRs, comments, commit bodies — follows
+this same baseline: an agent reads as what it is, an AI team member differentiated by role
+posture (its agent definition names the posture), never by an impersonated human voice. Output
+that ships under the maintainer's own identity additionally follows `voice.md` — its header
+carries the applicability test.
 
 ## Communication Style
+
+In-session dialog with the maintainer — not GitHub prose; a one-shot comment can't hold a
+position under pushback.
 
 If a plan or code looks wrong, say so up front, with the reason — not buried at the end or
 softened into a question. Hold that position under pushback until a new fact changes it, not until

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -4,8 +4,9 @@
      domain-specific — see domain/architecture.md. Rationale: claude/README.md. -->
 
 > ### GATE — applies always
+>
 > Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
-> A repo's DESIGN.md/ADRs *illustrate* these, never override them — read them and stay
+> A repo's DESIGN.md/ADRs _illustrate_ these, never override them — read them and stay
 > consistent. This is the source; the repo doc is the concrete expression.
 
 # Design Principles
@@ -27,7 +28,7 @@ a reviewable diff, not an invisible change to a local environment.
 
 Make obvious what owns a piece of logic, what boundary is crossed, what's already been validated,
 and what failed when something breaks. Achieve it in order: good names, then clear structure, then
-comments only where they preserve intent code can't. Comments explain *why*, not *what* — don't
+comments only where they preserve intent code can't. Comments explain _why_, not _what_ — don't
 narrate mechanics a good name already conveys.
 
 ## Small, Composable Tools

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -1,0 +1,84 @@
+<!-- Universal design principles. Canonical source: my dotfiles.
+     Loaded globally for every project. Language- and platform-agnostic.
+     How code and tools are shaped, not how work gets done (see engineering-practices.md)
+     or how the agent operates (see ai-collaboration.md, communication.md).
+     Application-layer architecture (layered design, artifacts) is domain-specific, not
+     universal — it lives in domain/architecture.md and loads only for layered apps. -->
+
+> ### GATE — applies always
+> These principles apply in their abstract form everywhere; there are no placeholders
+> to fill and nothing to distill into a repo. Do NOT copy this into repos.
+> If a repo documents its own design rationale (e.g. docs/DESIGN.md, ADRs), read it to
+> see how these principles are realized in that codebase, and stay consistent with its
+> recorded decisions. That repo doc is the concrete expression; this is the source.
+> This is never "overridden" by a repo — a repo doc illustrates it, it does not
+> replace it.
+
+# Design Principles
+
+How I want code, tools, and configuration shaped — everywhere. When a repository's own
+documents are more specific, follow those; they realize these principles.
+
+## Simplicity First
+
+Write the minimum code that solves the problem. No speculative flags, no configurability nobody
+asked for, no abstraction for a single call site, no error handling for a scenario that can't
+happen. Self-check: would a senior engineer call this overcomplicated? If yes, cut it back.
+
+## Configuration Is Code, Not Ambient State
+
+Tooling configuration — linter rules, formatter settings, hook definitions, CI behavior — is a
+versioned file in the repo, not a contributor's global dotfiles, IDE settings, or personal
+defaults. Same idea as Infrastructure as Code, applied to the toolchain itself.
+
+- If a rule matters, it lives in a config file every contributor and CI both read — not a wiki
+  page, a chat message, or "everyone just remembers to pass these flags."
+- One canonical config a tool reads directly beats the same rule restated in several places (an
+  IDE setting *and* a CI flag *and* a doc) that can silently drift apart.
+- Changing a rule is a reviewable diff to that file, not an undocumented change to someone's local
+  environment that the next contributor can't see or reproduce.
+
+## Code Should Explain Itself To The Next Reader
+
+Working code is not enough. Code should make obvious to the next reader what owns a piece of logic,
+what boundary is being crossed, what data has already been normalized or validated, what invariant is
+being enforced, and what stage failed when something goes wrong. Legibility is a first-class goal, not
+a nicety.
+
+Achieve it in order of preference: good names first, clear structure second, comments only where they
+preserve intent that code alone cannot. Comments are for reasoning, not narration — explain *why* a
+boundary, normalization, or unusual choice exists; do not restate obvious mechanics a good name
+already conveys. Before writing a comment, ask whether a better name or clearer structure would remove
+the need for it.
+
+## Small, Composable Tools
+
+The Unix philosophy — one tool, one job, done well, composed through clean interfaces. It governs
+which tools get reached for and how scripts or CLIs get shaped, the same one-job discipline applied
+outside the codebase.
+
+- Prefer a small tool that does one thing over a monolithic one that does many unrelated things
+  behind a pile of flags. Compose several small tools rather than growing one to cover every case.
+- Give a script or CLI a narrow, well-defined job with a clean interface — stdin/stdout, exit
+  codes, a small flag surface — so it composes with pipes and other tools instead of needing a
+  bespoke integration.
+- If a tool or script is doing two unrelated jobs, split it. Same test as a code unit: can it be
+  described in one sentence?
+
+## Naming & Files
+
+Names should reveal semantic meaning, ownership, level of abstraction, and whether a value is raw,
+normalized, validated, or emitted. Prefer names that describe responsibility or transformation, not
+implementation trivia; avoid vague names (`data`, `obj`, `tmp`, `thing`). Prefer typed errors whose
+names preserve stage meaning. Keep files topical and narrow; avoid dumping-ground files
+(`utils`, `helpers`, `misc`, `common`). If a unit can't be described in one sentence, it's doing too
+much.
+
+## Logs Are For Diagnosis, Output Is For Humans
+
+Keep a strong distinction: logs make failures diagnosable after the fact; user-facing output guides
+the operator now. Do not use one as a substitute for the other. Use log levels intentionally
+(detailed diagnostics; normal progress; degraded/partial; stopping failures). Keep logging close to
+the code that owns the truth. User-facing output should read as a concise narrative: prefer one
+structured block over overlapping lines, surface caveats before success, use action-oriented
+language, and never force the reader to read logs for ordinary mistakes.

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -1,84 +1,50 @@
-<!-- Universal design principles. Canonical source: my dotfiles.
-     Loaded globally for every project. Language- and platform-agnostic.
-     How code and tools are shaped, not how work gets done (see engineering-practices.md)
-     or how the agent operates (see ai-collaboration.md, communication.md).
-     Application-layer architecture (layered design, artifacts) is domain-specific, not
-     universal — it lives in domain/architecture.md and loads only for layered apps. -->
+<!-- Universal design principles. Canonical source: my dotfiles. Loaded globally.
+     How code and tools are shaped, not how work gets done (engineering-practices.md) or how
+     the agent operates (ai-collaboration.md, communication.md). Layered-app architecture is
+     domain-specific — see domain/architecture.md. Rationale: claude/README.md. -->
 
 > ### GATE — applies always
-> These principles apply in their abstract form everywhere; there are no placeholders
-> to fill and nothing to distill into a repo. Do NOT copy this into repos.
-> If a repo documents its own design rationale (e.g. docs/DESIGN.md, ADRs), read it to
-> see how these principles are realized in that codebase, and stay consistent with its
-> recorded decisions. That repo doc is the concrete expression; this is the source.
-> This is never "overridden" by a repo — a repo doc illustrates it, it does not
-> replace it.
+> Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
+> A repo's DESIGN.md/ADRs *illustrate* these, never override them — read them and stay
+> consistent. This is the source; the repo doc is the concrete expression.
 
 # Design Principles
-
-How I want code, tools, and configuration shaped — everywhere. When a repository's own
-documents are more specific, follow those; they realize these principles.
 
 ## Simplicity First
 
 Write the minimum code that solves the problem. No speculative flags, no configurability nobody
-asked for, no abstraction for a single call site, no error handling for a scenario that can't
-happen. Self-check: would a senior engineer call this overcomplicated? If yes, cut it back.
+asked for, no abstraction for a single call site, no handling for a case that can't happen.
+Self-check: would a senior engineer call this overcomplicated?
 
 ## Configuration Is Code, Not Ambient State
 
-Tooling configuration — linter rules, formatter settings, hook definitions, CI behavior — is a
-versioned file in the repo, not a contributor's global dotfiles, IDE settings, or personal
-defaults. Same idea as Infrastructure as Code, applied to the toolchain itself.
-
-- If a rule matters, it lives in a config file every contributor and CI both read — not a wiki
-  page, a chat message, or "everyone just remembers to pass these flags."
-- One canonical config a tool reads directly beats the same rule restated in several places (an
-  IDE setting *and* a CI flag *and* a doc) that can silently drift apart.
-- Changing a rule is a reviewable diff to that file, not an undocumented change to someone's local
-  environment that the next contributor can't see or reproduce.
+Tooling config — linter rules, formatter settings, hooks, CI behavior — is a versioned file every
+contributor and CI read, not someone's global dotfiles or IDE settings. One canonical config a
+tool reads directly beats the same rule restated in several places that drift. Changing a rule is
+a reviewable diff, not an invisible change to a local environment.
 
 ## Code Should Explain Itself To The Next Reader
 
-Working code is not enough. Code should make obvious to the next reader what owns a piece of logic,
-what boundary is being crossed, what data has already been normalized or validated, what invariant is
-being enforced, and what stage failed when something goes wrong. Legibility is a first-class goal, not
-a nicety.
-
-Achieve it in order of preference: good names first, clear structure second, comments only where they
-preserve intent that code alone cannot. Comments are for reasoning, not narration — explain *why* a
-boundary, normalization, or unusual choice exists; do not restate obvious mechanics a good name
-already conveys. Before writing a comment, ask whether a better name or clearer structure would remove
-the need for it.
+Make obvious what owns a piece of logic, what boundary is crossed, what's already been validated,
+and what failed when something breaks. Achieve it in order: good names, then clear structure, then
+comments only where they preserve intent code can't. Comments explain *why*, not *what* — don't
+narrate mechanics a good name already conveys.
 
 ## Small, Composable Tools
 
-The Unix philosophy — one tool, one job, done well, composed through clean interfaces. It governs
-which tools get reached for and how scripts or CLIs get shaped, the same one-job discipline applied
-outside the codebase.
-
-- Prefer a small tool that does one thing over a monolithic one that does many unrelated things
-  behind a pile of flags. Compose several small tools rather than growing one to cover every case.
-- Give a script or CLI a narrow, well-defined job with a clean interface — stdin/stdout, exit
-  codes, a small flag surface — so it composes with pipes and other tools instead of needing a
-  bespoke integration.
-- If a tool or script is doing two unrelated jobs, split it. Same test as a code unit: can it be
-  described in one sentence?
+One tool, one job, done well, composed through clean interfaces (stdin/stdout, exit codes, a small
+flag surface). Prefer composing small tools over growing one behind a pile of flags. If a tool or
+script does two unrelated jobs, split it — same one-sentence test as a code unit.
 
 ## Naming & Files
 
-Names should reveal semantic meaning, ownership, level of abstraction, and whether a value is raw,
-normalized, validated, or emitted. Prefer names that describe responsibility or transformation, not
-implementation trivia; avoid vague names (`data`, `obj`, `tmp`, `thing`). Prefer typed errors whose
-names preserve stage meaning. Keep files topical and narrow; avoid dumping-ground files
-(`utils`, `helpers`, `misc`, `common`). If a unit can't be described in one sentence, it's doing too
-much.
+Names reveal meaning, ownership, and whether a value is raw, normalized, validated, or emitted —
+not implementation trivia. Avoid vague names (`data`, `obj`, `tmp`) and dumping-ground files
+(`utils`, `helpers`, `misc`). If a unit can't be described in one sentence, it's doing too much.
 
 ## Logs Are For Diagnosis, Output Is For Humans
 
-Keep a strong distinction: logs make failures diagnosable after the fact; user-facing output guides
-the operator now. Do not use one as a substitute for the other. Use log levels intentionally
-(detailed diagnostics; normal progress; degraded/partial; stopping failures). Keep logging close to
-the code that owns the truth. User-facing output should read as a concise narrative: prefer one
-structured block over overlapping lines, surface caveats before success, use action-oriented
-language, and never force the reader to read logs for ordinary mistakes.
+Logs make failures diagnosable after the fact; user-facing output guides the operator now — don't
+substitute one for the other. Use log levels intentionally; keep logging close to the code that
+owns the truth. User-facing output reads as a concise narrative: one structured block over
+scattered lines, caveats before success, never make the reader read logs for an ordinary mistake.

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -31,6 +31,12 @@ and what failed when something breaks. Achieve it in order: good names, then cle
 comments only where they preserve intent code can't. Comments explain _why_, not _what_ — don't
 narrate mechanics a good name already conveys.
 
+When the why is recoverable elsewhere (an ADR, an issue, a PR), the comment can be a pointer —
+`# see ADR-0003` / `# see #142` — instead of restating that context inline. A pointer is not an
+omission: it leverages provenance without dropping intent. The load-bearing, non-obvious tripwire
+("removing this breaks X") still stays inline at the point of edit — a pointer supplements that,
+never replaces it.
+
 ## Small, Composable Tools
 
 One tool, one job, done well, composed through clean interfaces (stdin/stdout, exit codes, a small

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -47,6 +47,14 @@ omission: it leverages provenance without dropping intent. The load-bearing, non
 ("removing this breaks X") still stays inline at the point of edit — a pointer supplements that,
 never replaces it.
 
+A comment block on one declaration is **≤2 lines** — the tripwire plus its pointer. Over that,
+relocate the why to its ADR/issue home and leave the pointer. The inline tripwire is the terse
+actionable warning (what breaks + the revisit condition), kept within the cap; where its supporting
+rationale or evidence won't fit, that relocates to the pointer's target and the inline keeps only
+the warning + pointer. When a block mixes restatement and tripwire, the tripwire wins and the block
+stays. File-header preambles are out of scope — they're standalone documentation, not a
+per-declaration comment.
+
 ## Small, Composable Tools
 
 One tool, one job, done well, composed through clean interfaces (stdin/stdout, exit codes, a small

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -17,6 +17,16 @@ Write the minimum code that solves the problem. No speculative flags, no configu
 asked for, no abstraction for a single call site, no handling for a case that can't happen.
 Self-check: would a senior engineer call this overcomplicated?
 
+Once you understand the problem, find the minimum in order before writing anything new: does this
+need to exist at all? → is it already in this codebase? → the standard library? → a native
+platform feature? → an already-installed dependency? → can it be one line? → only then, the least
+code that works. The ladder runs _after_ understanding the problem, never instead of it.
+
+Terse is not fragile. The reuse search never trades away understanding the problem before coding,
+validation at trust boundaries, error handling that prevents data loss, security, or tests — leave
+at least one runnable check behind non-trivial logic. This is code-scoped: it governs code, not
+prose, docs, issue drafts, or agent-memory writes.
+
 ## Configuration Is Code, Not Ambient State
 
 Tooling config — linter rules, formatter settings, hooks, CI behavior — is a versioned file every

--- a/rules/universal/design-principles.md
+++ b/rules/universal/design-principles.md
@@ -1,7 +1,7 @@
-<!-- Universal design principles. Canonical source: my dotfiles. Loaded globally.
+<!-- Universal design principles. Canonical source: this repo. Loaded globally.
      How code and tools are shaped, not how work gets done (engineering-practices.md) or how
      the agent operates (ai-collaboration.md, communication.md). Layered-app architecture is
-     domain-specific — see domain/architecture.md. Rationale: claude/README.md. -->
+     domain-specific — see domain/architecture.md. Rationale: README.md. -->
 
 > ### GATE — applies always
 >

--- a/rules/universal/documentation.md
+++ b/rules/universal/documentation.md
@@ -1,0 +1,42 @@
+> ### GATE — applies always
+>
+> Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
+> A repo's own docs bind the specifics (where ADRs live, its templates); this is the source.
+
+# Documentation
+
+## Documentation Is Part Of The Change
+
+Update docs when behavior or architecture changes. Before a structural change, read the recorded
+decisions and stay consistent; if one must change, supersede it explicitly rather than letting code
+and intent drift. For a repo with real multi-session or multi-contributor handoff, keep a committed
+status/next-task file current — a judgment call, not a mandate.
+
+A major, cross-cutting, or expensive-to-reverse decision is _recorded_ in an ADR — the decision plus
+what was considered and rejected, not just the outcome — so it stays walkable later instead of an
+excavation of closed issues/PRs. The repo binds where the ADR lives and its exact template; this only
+says the artifact belongs somewhere durable, not buried in ephemeral history.
+
+## One home per fact, everything else points
+
+Each kind of documentation owns one job. A fact lives in exactly one of these; everywhere else points
+at it instead of restating it:
+
+| Artifact                  | Owns                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------- |
+| Issue / tracker           | The problem, design exploration, spikes, acceptance — the plan, around the work.                  |
+| PR / MR                   | The real-time journal: decisions, gotchas, retractions, forks as they happen.                     |
+| ADR                       | The durable record of a major decision: what was chosen, what was rejected, why.                  |
+| Agent guide (`AGENTS.md`) | How to work here; points at ADRs for the why instead of re-arguing it.                            |
+| README                    | What this is, install, use — the front door for a human reader.                                   |
+| Interface / API contract  | The consumption contract — inputs, outputs, types, behavior — in the code's types and docstrings. |
+| Code comments             | The tripwire why at the point of edit, plus a pointer if more context exists.                     |
+| Configs                   | The enforced spec — self-speaking; docs point at the config, not restate it.                      |
+
+A generated interface spec (e.g. `openapi.json`) is a derived artifact of the code's contract —
+regenerated from it, never a second hand-edited home.
+
+Once a decision has an ADR, later docs cite it (`see ADR-0003`) rather than re-explaining it — and
+never point back the other way (an ADR never says "see the AGENTS.md section for why"; that's the
+circular-pointer trap). Cover every fact's home in as few words as it takes; over-documenting beats
+leaving a decision unrecorded, but don't let restatement creep back in.

--- a/rules/universal/engineering-practices.md
+++ b/rules/universal/engineering-practices.md
@@ -3,6 +3,7 @@
      shaped in the moment (design-principles.md). Rationale: claude/README.md. -->
 
 > ### GATE — applies always
+>
 > Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
 > A repo's own testing/security docs are the concrete expression; this is the source.
 

--- a/rules/universal/engineering-practices.md
+++ b/rules/universal/engineering-practices.md
@@ -1,0 +1,47 @@
+<!-- Universal engineering practices. Canonical source: my dotfiles.
+     Loaded globally for every project. Language- and platform-agnostic.
+     How work gets done over time (testing, docs, refactoring, security), not how
+     code is shaped in the moment (see design-principles.md). -->
+
+> ### GATE — applies always
+> These principles apply in their abstract form everywhere; there are no placeholders
+> to fill and nothing to distill into a repo. Do NOT copy this into repos.
+> If a repo documents its own testing/security conventions, read them and stay
+> consistent — that repo doc is the concrete expression; this is the source.
+
+# Engineering Practices
+
+## Testing By Layer
+
+Different layers prove different things: core tests prove invariants; boundary tests prove
+normalization and error translation; orchestration tests prove sequencing and stage behavior; output
+tests prove artifact and logging contracts. Prefer focused tests near the boundary where behavior
+lives, fakes over live infrastructure, and regression tests placed where the bug lived. Don't turn
+every question into an end-to-end test, and don't leave a test in a package that no longer owns the
+behavior.
+
+## Refactoring
+
+Refactor to improve boundary clarity, separation of concerns, naming accuracy, testability, and
+explicit handoffs, or to remove accidental duplication. Good refactors move logic toward the layer
+that should own it. Avoid abstraction without a real boundary, hiding sequencing, centralizing
+unrelated concerns into generic utility packages, or splitting files in ways that obscure ownership.
+
+## Security By Default
+
+Flag common vulnerability classes (injection, unsafe deserialization, path traversal, secrets in
+code, and similar) even when not asked — don't wait to be prompted about a risk that's visible in
+the diff. Secrets live in an environment file or a secret manager, gitignored, never hardcoded or
+committed, even temporarily.
+
+## Documentation Is Part Of The Change
+
+Update docs when behavior or architecture changes — user-visible behavior, design/seam changes,
+standards, and durable decisions each have a home. Before a structural change, read the recorded
+decisions and stay consistent with them; if one must change, supersede it explicitly rather than
+letting code and recorded intent drift apart. Write down anything the next reader will need.
+
+For a repo with real multi-session or multi-contributor handoff needs, a committed, human-readable
+status/next-task file (current progress, what's next, anything a fresh session would need) is worth
+keeping current — not a mandate for every repo, but a judgment call where picking up mid-task
+actually happens often.

--- a/rules/universal/engineering-practices.md
+++ b/rules/universal/engineering-practices.md
@@ -34,3 +34,9 @@ Update docs when behavior or architecture changes. Before a structural change, r
 decisions and stay consistent; if one must change, supersede it explicitly rather than letting
 code and intent drift. For a repo with real multi-session or multi-contributor handoff, keep a
 committed status/next-task file current — a judgment call, not a mandate.
+
+A major, cross-cutting, or expensive-to-reverse decision is "recorded" in an ADR — the
+decision plus what was considered and rejected, not just the outcome — so it stays
+walkable later instead of requiring an excavation of closed issues/PRs. A repo's own
+docs define where that ADR lives and its exact template; this principle only says the
+artifact belongs somewhere durable, not buried in ephemeral history.

--- a/rules/universal/engineering-practices.md
+++ b/rules/universal/engineering-practices.md
@@ -1,47 +1,35 @@
-<!-- Universal engineering practices. Canonical source: my dotfiles.
-     Loaded globally for every project. Language- and platform-agnostic.
-     How work gets done over time (testing, docs, refactoring, security), not how
-     code is shaped in the moment (see design-principles.md). -->
+<!-- Universal engineering practices. Canonical source: my dotfiles. Loaded globally.
+     How work gets done over time (testing, docs, refactoring, security), not how code is
+     shaped in the moment (design-principles.md). Rationale: claude/README.md. -->
 
 > ### GATE — applies always
-> These principles apply in their abstract form everywhere; there are no placeholders
-> to fill and nothing to distill into a repo. Do NOT copy this into repos.
-> If a repo documents its own testing/security conventions, read them and stay
-> consistent — that repo doc is the concrete expression; this is the source.
+> Applies everywhere; no placeholders, nothing to distill. Do NOT copy into repos.
+> A repo's own testing/security docs are the concrete expression; this is the source.
 
 # Engineering Practices
 
 ## Testing By Layer
 
-Different layers prove different things: core tests prove invariants; boundary tests prove
-normalization and error translation; orchestration tests prove sequencing and stage behavior; output
-tests prove artifact and logging contracts. Prefer focused tests near the boundary where behavior
-lives, fakes over live infrastructure, and regression tests placed where the bug lived. Don't turn
-every question into an end-to-end test, and don't leave a test in a package that no longer owns the
-behavior.
+Different layers prove different things — invariants at the core, normalization and error
+translation at the boundary, sequencing in orchestration. Prefer focused tests near the behavior,
+fakes over live infrastructure, and regression tests where the bug lived. Don't make everything
+end-to-end, and don't leave a test in a package that no longer owns the behavior.
 
 ## Refactoring
 
-Refactor to improve boundary clarity, separation of concerns, naming accuracy, testability, and
-explicit handoffs, or to remove accidental duplication. Good refactors move logic toward the layer
-that should own it. Avoid abstraction without a real boundary, hiding sequencing, centralizing
-unrelated concerns into generic utility packages, or splitting files in ways that obscure ownership.
+Refactor for boundary clarity, separation of concerns, naming, testability, or to remove
+accidental duplication — moving logic toward the layer that should own it. Avoid abstraction
+without a real boundary, hidden sequencing, or splits that obscure ownership.
 
 ## Security By Default
 
 Flag common vulnerability classes (injection, unsafe deserialization, path traversal, secrets in
-code, and similar) even when not asked — don't wait to be prompted about a risk that's visible in
-the diff. Secrets live in an environment file or a secret manager, gitignored, never hardcoded or
-committed, even temporarily.
+code) even when not asked — don't wait to be prompted about a risk visible in the diff. Secrets
+live in an environment file or secret manager, gitignored, never hardcoded or committed.
 
 ## Documentation Is Part Of The Change
 
-Update docs when behavior or architecture changes — user-visible behavior, design/seam changes,
-standards, and durable decisions each have a home. Before a structural change, read the recorded
-decisions and stay consistent with them; if one must change, supersede it explicitly rather than
-letting code and recorded intent drift apart. Write down anything the next reader will need.
-
-For a repo with real multi-session or multi-contributor handoff needs, a committed, human-readable
-status/next-task file (current progress, what's next, anything a fresh session would need) is worth
-keeping current — not a mandate for every repo, but a judgment call where picking up mid-task
-actually happens often.
+Update docs when behavior or architecture changes. Before a structural change, read the recorded
+decisions and stay consistent; if one must change, supersede it explicitly rather than letting
+code and intent drift. For a repo with real multi-session or multi-contributor handoff, keep a
+committed status/next-task file current — a judgment call, not a mandate.

--- a/rules/universal/engineering-practices.md
+++ b/rules/universal/engineering-practices.md
@@ -27,16 +27,3 @@ without a real boundary, hidden sequencing, or splits that obscure ownership.
 Flag common vulnerability classes (injection, unsafe deserialization, path traversal, secrets in
 code) even when not asked — don't wait to be prompted about a risk visible in the diff. Secrets
 live in an environment file or secret manager, gitignored, never hardcoded or committed.
-
-## Documentation Is Part Of The Change
-
-Update docs when behavior or architecture changes. Before a structural change, read the recorded
-decisions and stay consistent; if one must change, supersede it explicitly rather than letting
-code and intent drift. For a repo with real multi-session or multi-contributor handoff, keep a
-committed status/next-task file current — a judgment call, not a mandate.
-
-A major, cross-cutting, or expensive-to-reverse decision is "recorded" in an ADR — the
-decision plus what was considered and rejected, not just the outcome — so it stays
-walkable later instead of requiring an excavation of closed issues/PRs. A repo's own
-docs define where that ADR lives and its exact template; this principle only says the
-artifact belongs somewhere durable, not buried in ephemeral history.

--- a/rules/universal/engineering-practices.md
+++ b/rules/universal/engineering-practices.md
@@ -1,6 +1,6 @@
-<!-- Universal engineering practices. Canonical source: my dotfiles. Loaded globally.
+<!-- Universal engineering practices. Canonical source: this repo. Loaded globally.
      How work gets done over time (testing, docs, refactoring, security), not how code is
-     shaped in the moment (design-principles.md). Rationale: claude/README.md. -->
+     shaped in the moment (design-principles.md). Rationale: README.md. -->
 
 > ### GATE — applies always
 >

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -3,10 +3,12 @@ name: audit-memory
 description: >-
   Read-only audit of a repo's subagent project-memory (`.claude/agent-memory/<name>/`) for
   staleness against live GitHub state, one-home duplication of issue content, a drifted MEMORY.md
-  index, and sprawl — reporting proposed fixes without editing anything. Use when asked to audit,
-  review, or check agent/backlog-manager memory for stale pointers, restated issue status,
-  orphaned or dangling memory files, or files that have grown too long. The detection backstop to
-  the write-time discipline in `backlog-manager.md`. Read-only — never invoke it to apply a fix.
+  index, sprawl, and durable content that belongs in README/AGENTS.md/docs instead — reporting
+  proposed fixes without editing anything. Use when asked to audit, review, or check
+  agent/backlog-manager memory for stale pointers, restated issue status, orphaned or dangling
+  memory files, files that have grown too long, or memory content that should live in repo docs
+  instead. The detection backstop to the write-time discipline in `backlog-manager.md`. Read-only
+  — never invoke it to apply a fix.
 allowed-tools: Read, Glob, Grep, Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh search issues:*), Bash(gh label list:*)
 disallowed-tools: Write, Edit
 ---
@@ -46,6 +48,12 @@ Bound the glob carefully — the tree has decoys that will corrupt the checks if
 If the repo has no `.claude/agent-memory/` (the skill deploys globally; the memory only exists
 where a subagent has actually run), say so and stop — "no agent memory in this repo," not a pile
 of empty findings.
+
+Also read this repo's `README.md`, `AGENTS.md` (or the `CLAUDE.md` it's symlinked from), and
+top-level `docs/*.md` when they exist — comparison targets for the Misplaced durable content check
+below, not optional context. Not recursive into `docs/` subdirectories (an `adr/` archive of
+point-in-time decisions is expected to reference or echo doc content by nature, not drift by
+accident) — same scope `audit-rules`' Cross-doc replication check uses; don't re-derive it here.
 
 ## Staleness vs live GitHub state
 
@@ -99,6 +107,32 @@ Same shapes as `audit-rules`, calibrated for memory:
 - **Contradiction** — two memory files (or two sections) asserting opposite facts, the way
   `audit-rules` checks the rules tree. Quote both, say which looks current.
 
+## Misplaced durable content
+
+The doc↔memory sibling of `audit-rules`' Cross-doc replication check: content sitting in memory
+that's actually general repo documentation, not backlog-manager-audience material, and isn't
+already stated in README.md/AGENTS.md/docs.
+
+**Scope**: `project`- and `reference`-type entries only — check each file's `metadata: type:`
+frontmatter. Skip `user`- and `feedback`-type entries outright; they're about how to work with the
+maintainer, not repo-documentation material, by nature — never flag them here.
+
+**What counts as misplaced**: a passage in scope whose content would inform any future contributor
+or coding session, not just a triage/grooming session, and isn't already stated in
+README.md/AGENTS.md/docs. Durability alone doesn't make something misplaced — audience does: a
+decision's priority weighting, a labeling/grooming convention, or a cross-repo dependency web is
+backlog-manager-audience by nature and stays put even though it's durable. An architecture
+rationale, an XDG exception, or a convention any coding session would need is the target.
+
+For each finding: quote the memory passage, name which doc should own it — reuse this repo's own
+doc-home split if one exists (README = front door, AGENTS.md = how to work here, an ADR = a major
+decision with rejected alternatives considered), exactly as `audit-rules`' Cross-doc replication
+check already does; don't re-derive the split inline — and propose shrinking the memory passage to
+a pointer once promoted, matching the signpost pattern used everywhere else in this repo's docs.
+
+Stay conservative, the same "quiet on noise" bar as every other check here: don't flag a claim just
+because it's durable — it has to be general-audience _and_ absent from README/AGENTS.md/docs.
+
 ## Report
 
 Emit one structured markdown report directly in this response:
@@ -121,6 +155,10 @@ No edits made — this is a proposal only.
 (ranked, or "None found.")
 
 ## Sprawl & contradiction
+
+(ranked, or "None found.")
+
+## Misplaced durable content
 
 (ranked, or "None found.")
 

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: audit-memory
+description: >-
+  Read-only audit of a repo's subagent project-memory (`.claude/agent-memory/<name>/`) for
+  staleness against live GitHub state, one-home duplication of issue content, a drifted MEMORY.md
+  index, and sprawl — reporting proposed fixes without editing anything. Use when asked to audit,
+  review, or check agent/backlog-manager memory for stale pointers, restated issue status,
+  orphaned or dangling memory files, or files that have grown too long. The detection backstop to
+  the write-time discipline in `backlog-manager.md`. Read-only — never invoke it to apply a fix.
+allowed-tools: Read, Glob, Grep, Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh search issues:*), Bash(gh label list:*)
+disallowed-tools: Write, Edit
+---
+
+# Audit Memory
+
+Read-only audit of a subagent's committed project memory — the detection half of keeping that
+memory honest, paired with the write-time "read `origin/main` before writing" discipline in
+`backlog-manager.md` (prevention). Sibling to `audit-rules`: same propose-don't-apply contract,
+same report shape, a different target. Report findings and proposed fixes — never edit anything.
+
+**The auditor is not the author.** This runs as its own skill precisely so the actor that writes
+memory doesn't grade its own work — a deliberate independent read, the same reason `audit-rules`
+exists as a separate pass. Don't invoke it _as_ the backlog-manager.
+
+**On the read-only guarantee.** `disallowed-tools` blocks Write/Edit, and Bash is scoped in
+`allowed-tools` to read-only `gh` queries (`view`/`list`/`search`, `label list`). That's a
+narrower guarantee than `audit-rules`' no-Bash-at-all — `gh` is also a _write_ interface — so the
+rule is explicit: only ever run those read subcommands. Never `gh issue close/edit/comment`, never
+`gh api` with a mutating method, never shell redirection or `sed -i`. If a check needs a write,
+it's out of scope — report it, don't do it.
+
+## Scope
+
+Audit the current repo's `.claude/agent-memory/*/` — each subagent's own memory directory, its
+`MEMORY.md` index plus the topic `*.md` files beside it. Read those files directly.
+
+Bound the glob carefully — the tree has decoys that will corrupt the checks if swept in:
+
+- Match `.claude/agent-memory/*/*.md` only (each subagent dir, one level of files). **Not**
+  recursive.
+- Exclude `.claude/worktrees/**` — linked worktrees carry their own mirrored copies of the memory.
+- Exclude any self-nested `.claude/agent-memory/**/.claude/agent-memory/**` copy — accidental cruft
+  from a run whose working directory sat inside the memory dir. If you find one, note it as a stray
+  artifact to delete, but don't audit its contents as if they were real.
+
+If the repo has no `.claude/agent-memory/` (the skill deploys globally; the memory only exists
+where a subagent has actually run), say so and stop — "no agent memory in this repo," not a pile
+of empty findings.
+
+## Staleness vs live GitHub state
+
+Memory is meant to hold decisions and _point at_ issues for status — `MEMORY.md` says so:
+"live status lives on the issue." So the target is not a bare reference to a now-closed issue
+(referencing a shipped record is correct); it's an **assertion of fact the memory embeds that
+current state contradicts**.
+
+- Flag embedded status claims — `#302 (OPEN)`, `#273 (OPEN, priority low)`, "not created yet",
+  "still blocking", "superseded by" — and cross-check each against live state with a read-only `gh`
+  query (`gh issue view <n>`). Report any that have moved: memory says open, `gh` says closed;
+  memory says "not created yet" for a label that now exists.
+- Prefer the DRY remedy over an in-place correction: an embedded live status duplicates what the
+  issue already owns, so the fix is usually **drop the restated status and point at `#N`**, not
+  "update the number." That folds this finding into the one-home check below — say so when it
+  applies. Correcting-in-place is only right for a genuinely durable claim that isn't the issue's to
+  own.
+
+Stay conservative, the same "quiet on noise" bar as `audit-rules`: a bare `#N` cross-reference,
+or naming an issue as a parent/child, is not a staleness finding.
+
+## One-home duplication
+
+The single-source-of-truth check, pointed at memory: a memory file restating an issue's body (its
+description, acceptance criteria, current status) instead of holding the _decision and why_ and
+pointing at the issue. Also flag the same fact restated across two memory files — it should live in
+one and be pointed at from the other, exactly as `audit-rules`' Cross-doc replication treats
+AGENTS.md/README.
+
+Substantial means the same claim with the same specifics, not a shared issue number or tool name.
+For each, quote both places and propose which one keeps it and which points instead.
+
+## Broken index
+
+`MEMORY.md` is the loaded-every-session index; the topic files are its targets. Flag the two ways
+they drift apart:
+
+- **Dangling pointer** — `MEMORY.md` links a file (`[label](topic.md)`) that doesn't exist.
+- **Orphan** — a topic `*.md` in the directory that nothing in `MEMORY.md` links to (so it's never
+  discovered). Exclude `MEMORY.md` itself from this check — it's the index, not an indexed file.
+
+## Sprawl and contradiction
+
+Same shapes as `audit-rules`, calibrated for memory:
+
+- **Length / topic span** — these are heredoc-authored working notes, not published prose (they're
+  exempt from the markdownlint/prettier hooks for that reason), so don't hold them to a published-doc
+  line count. `MEMORY.md` should stay a lean index; a topic file that has outgrown its single
+  subject or drifted into covering several unrelated facts is the target — judged by topic span
+  first, with length only the symptom. Propose the split or the prune.
+- **Contradiction** — two memory files (or two sections) asserting opposite facts, the way
+  `audit-rules` checks the rules tree. Quote both, say which looks current.
+
+## Report
+
+Emit one structured markdown report directly in this response:
+
+```markdown
+# Memory Audit
+
+No edits made — this is a proposal only.
+
+## Staleness
+
+(ranked most-confident first, or "None found.")
+
+## One-home duplication
+
+(ranked, or "None found.")
+
+## Broken index
+
+(ranked, or "None found.")
+
+## Sprawl & contradiction
+
+(ranked, or "None found.")
+
+No edits made — this is a proposal only.
+```
+
+Each item is self-contained: what's wrong, where (file + quote), and a proposed direction — a
+suggestion, not a diff, since this skill cannot write. Applying any fix, and committing the result
+through the normal `chore(claude): sync <agent> memory` flow, stays a human call.

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -126,6 +126,14 @@ Two boundaries, fixed deliberately:
 - **"The issue" is not a promotion target for this check.** Memory↔issue traffic is already owned
   by the Staleness and One-home checks above; this check stays the doc↔memory sibling.
 
+**Mode split by filename** (ADR-0033's Residency section): a file matching `map_*.md` is a
+cross-repo map entry and gets a **structural** check instead of the audience judgment below. Its
+body must be exactly: repo name; memory-store location; one one-line hook; optionally a
+checkout-path hint marked non-portable; optionally pending-relocation pointer(s), each exactly
+`<repo>#<N>` plus at most a one-line hook — prose beyond the schema is a finding, judged
+per-pointer. No semantic "does this inform another repo's backlog" judgment anywhere — shape,
+not meaning. Everything below applies to non-map files only.
+
 **Scope**: `project`- and `reference`-type entries only — check each file's `metadata: type:`
 frontmatter. Skip `user`- and `feedback`-type entries outright; they're about how to work with the
 maintainer, not repo-documentation material, by nature — never flag them here.

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: audit-memory
 description: >-
-  Read-only audit of a repo's subagent project-memory (`.claude/agent-memory/<name>/`) for
-  staleness against live GitHub state, one-home duplication of issue content, a drifted MEMORY.md
-  index, sprawl, and durable content that belongs in a durable documentation home
-  (README/AGENTS.md/ADR) instead — reporting
-  proposed fixes without editing anything. Use when asked to audit, review, or check
-  agent/backlog-manager memory for stale pointers, restated issue status, orphaned or dangling
-  memory files, files that have grown too long, or memory content that should live in repo docs
-  instead. The detection backstop to the write-time discipline in `backlog-manager.md`. Read-only
-  — never invoke it to apply a fix.
-allowed-tools: Read, Glob, Grep, Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh search issues:*), Bash(gh label list:*)
+  Read-only audit of backlog-manager's MCP knowledge-graph memory (the JSONL store at
+  `~/.claude/agent-memory-mcp/backlog-manager.jsonl`) for staleness against live GitHub state,
+  one-home duplication of issue content, broken graph structure (dangling relations, orphaned
+  entities, malformed repo-map entities), sprawl, and durable content that belongs in a durable
+  documentation home (README/AGENTS.md/ADR) instead — reporting proposed fixes without editing
+  anything. Use when asked to audit, review, or check agent/backlog-manager memory for stale
+  pointers, restated issue status, orphaned entities, entities that have outgrown one topic, or
+  memory content that should live in repo docs instead. The detection backstop to the write-time
+  contract in `backlog-manager.md`. Read-only — never invoke it to apply a fix.
+allowed-tools: Read, Glob, Grep, Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh search issues:*), Bash(gh label list:*), Bash(jq:*)
 disallowed-tools: Write, Edit
 ---
 
 # Audit Memory
 
-Read-only audit of a subagent's committed project memory — the detection half of keeping that
-memory honest, paired with the write-time "read `origin/main` before writing" discipline in
-`backlog-manager.md` (prevention). Sibling to `audit-rules`: same propose-don't-apply contract,
-same report shape, a different target. Report findings and proposed fixes — never edit anything.
+Read-only audit of backlog-manager's knowledge-graph memory — the detection half of keeping that
+memory honest, paired with the write-time pointer-layer contract in `backlog-manager.md`
+(prevention; ADR-0036 owns the model). Sibling to `audit-rules`: same propose-don't-apply
+contract, same report shape, a different target. Report findings and proposed fixes — never edit
+anything.
 
 **The auditor is not the author.** This runs as its own skill precisely so the actor that writes
 memory doesn't grade its own work — a deliberate independent read, the same reason `audit-rules`
@@ -27,132 +28,134 @@ exists as a separate pass. Don't invoke it _as_ the backlog-manager — and sinc
 its caller's context, a session that wrote memory runs it via a **fresh-context subagent**
 pointed at this file, never inline (the sanctioned pattern per #412's spike decision).
 
-**On the read-only guarantee.** `disallowed-tools` blocks Write/Edit, and Bash is scoped in
-`allowed-tools` to read-only `gh` queries (`view`/`list`/`search`, `label list`). That's a
-narrower guarantee than `audit-rules`' no-Bash-at-all — `gh` is also a _write_ interface — so the
-rule is explicit: only ever run those read subcommands. Never `gh issue close/edit/comment`, never
-`gh api` with a mutating method, never shell redirection or `sed -i`. If a check needs a write,
-it's out of scope — report it, don't do it.
+**On the read-only guarantee.** `disallowed-tools` blocks Write/Edit; the store is read as a
+plain file (Read/jq), never through the `mcp__memory` write-capable tools; and Bash is scoped in
+`allowed-tools` to read-only `gh` queries (`view`/`list`/`search`, `label list`) plus `jq`.
+`gh` is also a _write_ interface, so the rule is explicit: only ever run those read subcommands.
+Never `gh issue close/edit/comment`, never `gh api` with a mutating method, never shell
+redirection into the store or `sed -i`. If a check needs a write, it's out of scope — report it,
+don't do it.
 
 ## Scope
 
-Audit the current repo's `.claude/agent-memory/*/` — each subagent's own memory directory, its
-`MEMORY.md` index plus the topic `*.md` files beside it. Read those files directly.
+Audit the machine-global store `~/.claude/agent-memory-mcp/backlog-manager.jsonl` — one JSONL
+file, one record per line: `{"type":"entity","name":...,"entityType":...,"observations":[...]}`
+or `{"type":"relation","from":...,"to":...,"relationType":...}`. Read it directly (Read or jq);
+it is deliberately human-readable (ADR-0036). If the file is missing or empty, say so and stop —
+"no graph memory on this machine," not a pile of empty findings.
 
-Bound the glob carefully — the tree has decoys that will corrupt the checks if swept in:
+The graph spans every repo. Repo scoping is relational: `repo-map` entities name the repos;
+`informs` relations tie repo-scoped facts to them. Doc-comparison checks (Misplaced durable
+content) judge a fact against the docs of the repo it informs — run them for repos with a
+checkout you can read (probe the `repo-map` entity's checkout hint; it's marked non-portable, a
+wrong value means _unknown_); list any repo you skipped for lack of a checkout rather than
+silently narrowing.
 
-- Match `.claude/agent-memory/*/*.md` only (each subagent dir, one level of files). **Not**
-  recursive.
-- Exclude `.claude/worktrees/**` — linked worktrees carry their own mirrored copies of the memory.
-- Exclude any self-nested `.claude/agent-memory/**/.claude/agent-memory/**` copy — accidental cruft
-  from a run whose working directory sat inside the memory dir. If you find one, note it as a stray
-  artifact to delete, but don't audit its contents as if they were real.
-
-If the repo has no `.claude/agent-memory/` (the skill deploys globally; the memory only exists
-where a subagent has actually run), say so and stop — "no agent memory in this repo," not a pile
-of empty findings.
-
-Also read this repo's `README.md`, `AGENTS.md` (or the `CLAUDE.md` it's symlinked from), and
-top-level `docs/*.md` when they exist — comparison targets for the Misplaced durable content check
-below, not optional context. Not recursive into `docs/` subdirectories (an `adr/` archive of
-point-in-time decisions is expected to reference or echo doc content by nature, not drift by
-accident) — same scope `audit-rules`' Cross-doc replication check uses; don't re-derive it here.
+For each repo audited, read its `README.md`, `AGENTS.md` (or the `CLAUDE.md` it's symlinked
+from), and top-level `docs/*.md` when they exist — comparison targets for the Misplaced durable
+content check, not optional context. Not recursive into `docs/` subdirectories (an `adr/`
+archive of point-in-time decisions is expected to reference or echo doc content by nature, not
+drift by accident) — same scope `audit-rules`' Cross-doc replication check uses; don't re-derive
+it here.
 
 ## Staleness vs live GitHub state
 
-Memory is meant to hold decisions and _point at_ issues for status — `MEMORY.md` says so:
-"live status lives on the issue." So the target is not a bare reference to a now-closed issue
-(referencing a shipped record is correct); it's an **assertion of fact the memory embeds that
-current state contradicts**.
+Memory is meant to hold decisions and _point at_ issues for status — the contract says so: live
+status lives on the issue. So the target is not a bare reference to a now-closed issue
+(referencing a shipped record is correct); it's an **assertion of fact an observation embeds
+that current state contradicts**.
 
-- Flag embedded status claims — `#302 (OPEN)`, `#273 (OPEN, priority low)`, "not created yet",
-  "still blocking", "superseded by" — and cross-check each against live state with a read-only `gh`
-  query (`gh issue view <n>`). Report any that have moved: memory says open, `gh` says closed;
-  memory says "not created yet" for a label that now exists.
+- Flag embedded status claims — `#302 (OPEN)`, "not created yet", "still blocking", "pending
+  write" — and cross-check each against live state with a read-only `gh` query
+  (`gh issue view <n> -R <owner>/<repo>`; resolve a bare `#N` through the entity's `informs`
+  relation). Report any that have moved: memory says open, `gh` says closed; memory says "not
+  created yet" for a label that now exists.
 - Prefer the DRY remedy over an in-place correction: an embedded live status duplicates what the
   issue already owns, so the fix is usually **drop the restated status and point at `#N`**, not
   "update the number." That folds this finding into the one-home check below — say so when it
-  applies. Correcting-in-place is only right for a genuinely durable claim that isn't the issue's to
-  own.
+  applies. Correcting-in-place is only right for a genuinely durable claim that isn't the
+  issue's to own.
 
 Stay conservative, the same "quiet on noise" bar as `audit-rules`: a bare `#N` cross-reference,
 or naming an issue as a parent/child, is not a staleness finding.
 
 ## One-home duplication
 
-The single-source-of-truth check, pointed at memory: a memory file restating an issue's body (its
-description, acceptance criteria, current status) instead of holding the _decision and why_ and
-pointing at the issue. Also flag the same fact restated across two memory files — it should live in
-one and be pointed at from the other, exactly as `audit-rules`' Cross-doc replication treats
-AGENTS.md/README.
+The single-source-of-truth check, pointed at memory: an observation restating an issue's body
+(its description, acceptance criteria, current status) instead of holding the _decision and why_
+and pointing at the issue. Also flag the same fact restated across two entities — it should live
+on one and be reachable from the other (a `relates-to` relation, or a pointer observation),
+exactly as `audit-rules`' Cross-doc replication treats AGENTS.md/README.
 
-Substantial means the same claim with the same specifics, not a shared issue number or tool name.
-For each, quote both places and propose which one keeps it and which points instead.
+Substantial means the same claim with the same specifics, not a shared issue number or tool
+name. For each, quote both places and propose which entity keeps it and which points instead.
 
-## Broken index
+## Broken graph
 
-`MEMORY.md` is the loaded-every-session index; the topic files are its targets. Flag the two ways
-they drift apart:
+The structural checks — shape, not meaning:
 
-- **Dangling pointer** — `MEMORY.md` links a file (`[label](topic.md)`) that doesn't exist.
-- **Orphan** — a topic `*.md` in the directory that nothing in `MEMORY.md` links to (so it's never
-  discovered). Exclude `MEMORY.md` itself from this check — it's the index, not an indexed file.
+- **Dangling relation** — a relation whose `from` or `to` names no entity in the store.
+- **Orphan fact** — a `project`- or `reference`-type entity with no `informs` relation to any
+  `repo-map` entity (so repo-scoped recall never reaches it). `user`/`feedback` entities are
+  legitimately global — never orphans.
+- **Duplicate entity names** — two entity lines with the same `name` (the server treats names as
+  identity; a duplicate means a write bypassed it or a merge went wrong).
+- **Malformed repo-map** — a `repo-map` entity's observations must be exactly: a one-line hook;
+  optionally a checkout-path hint marked non-portable; optionally pending-relocation pointer(s),
+  each exactly `<repo>#<N>` plus at most a one-line hook. Prose beyond that schema is a finding,
+  judged per-observation. No semantic judgment — the `entityType` is the mode selector, same as
+  the old filename split.
+- **Malformed record** — a line that isn't valid JSON, or an entity whose `entityType` isn't one
+  of `project`/`reference`/`user`/`feedback`/`repo-map`.
 
 ## Sprawl and contradiction
 
-Same shapes as `audit-rules`, calibrated for memory:
+Same shapes as `audit-rules`, calibrated for a graph:
 
-- **Length / topic span** — these are heredoc-authored working notes, not published prose (they're
-  exempt from the markdownlint/prettier hooks for that reason), so don't hold them to a published-doc
-  line count. `MEMORY.md` should stay a lean index; a topic file that has outgrown its single
-  subject or drifted into covering several unrelated facts is the target — judged by topic span
-  first, with length only the symptom. Propose the split or the prune.
-- **Contradiction** — two memory files (or two sections) asserting opposite facts, the way
-  `audit-rules` checks the rules tree. Quote both, say which looks current.
+- **Topic span** — one entity whose observations have drifted across several unrelated subjects;
+  the entity name should describe all of them and can't. Judged by topic span first, with
+  observation count only the symptom. Propose the split (new entity + relation) or the prune.
+- **Contradiction** — two observations (same entity or different ones) asserting opposite facts,
+  the way `audit-rules` checks the rules tree. Quote both, say which looks current.
 
 ## Misplaced durable content
 
 The doc↔memory sibling of `audit-rules`' Cross-doc replication check: content sitting in memory
 that belongs in a durable documentation home — README, AGENTS.md, or an ADR — rather than in
-memory, because it's general repo documentation, not backlog-manager-audience material, and isn't
-already stated in README.md/AGENTS.md/docs. The spec for what memory may hold at all is ADR-0033
-(memory is a pointer layer, keyed to the frontmatter types); this check is its lint.
+memory, because it's general repo documentation, not backlog-manager-audience material, and
+isn't already stated in README.md/AGENTS.md/docs. The spec for what memory may hold at all is
+the pointer-layer contract (ADR-0033, carried into ADR-0036); this check is its lint.
 
 Two boundaries, fixed deliberately:
 
-- The Scope section's `adr/` read-exclusion stands even though an ADR is now a named promotion
+- The Scope section's `adr/` read-exclusion stands even though an ADR is a named promotion
   target: ADR is a _proposal target_, never a read-surface for de-dup suppression. Promotion
   leaves only a pointer in memory, so there's nothing left to false-positive on.
-- **"The issue" is not a promotion target for this check.** Memory↔issue traffic is already owned
-  by the Staleness and One-home checks above; this check stays the doc↔memory sibling.
+- **"The issue" is not a promotion target for this check.** Memory↔issue traffic is already
+  owned by the Staleness and One-home checks above; this check stays the doc↔memory sibling.
 
-**Mode split by filename** (ADR-0033's Residency section): a file matching `map_*.md` is a
-cross-repo map entry and gets a **structural** check instead of the audience judgment below. Its
-body must be exactly: repo name; memory-store location; one one-line hook; optionally a
-checkout-path hint marked non-portable; optionally pending-relocation pointer(s), each exactly
-`<repo>#<N>` plus at most a one-line hook — prose beyond the schema is a finding, judged
-per-pointer. No semantic "does this inform another repo's backlog" judgment anywhere — shape,
-not meaning. Everything below applies to non-map files only.
+**Scope**: `project`- and `reference`-type entities only. Skip `user`- and `feedback`-type
+entities outright; they're about how to work with the maintainer, not repo-documentation
+material, by nature — never flag them here. `repo-map` entities are owned by the structural
+check above.
 
-**Scope**: `project`- and `reference`-type entries only — check each file's `metadata: type:`
-frontmatter. Skip `user`- and `feedback`-type entries outright; they're about how to work with the
-maintainer, not repo-documentation material, by nature — never flag them here.
+**What counts as misplaced**: an observation in scope whose content would inform any future
+contributor or coding session, not just a triage/grooming session, and isn't already stated in
+that repo's README.md/AGENTS.md/docs. Durability alone doesn't make something misplaced —
+audience does: a decision's priority weighting, a labeling/grooming convention, or a cross-repo
+dependency web is backlog-manager-audience by nature and stays put even though it's durable. An
+architecture rationale, an XDG exception, or a convention any coding session would need is the
+target.
 
-**What counts as misplaced**: a passage in scope whose content would inform any future contributor
-or coding session, not just a triage/grooming session, and isn't already stated in
-README.md/AGENTS.md/docs. Durability alone doesn't make something misplaced — audience does: a
-decision's priority weighting, a labeling/grooming convention, or a cross-repo dependency web is
-backlog-manager-audience by nature and stays put even though it's durable. An architecture
-rationale, an XDG exception, or a convention any coding session would need is the target.
+For each finding: quote the observation, name which doc should own it — reuse that repo's own
+doc-home split if one exists (README = front door, AGENTS.md = how to work here, an ADR = a
+major decision with rejected alternatives considered), exactly as `audit-rules`' Cross-doc
+replication check already does; don't re-derive the split inline — and propose shrinking the
+observation to a pointer once promoted, matching the signpost pattern used everywhere else.
 
-For each finding: quote the memory passage, name which doc should own it — reuse this repo's own
-doc-home split if one exists (README = front door, AGENTS.md = how to work here, an ADR = a major
-decision with rejected alternatives considered), exactly as `audit-rules`' Cross-doc replication
-check already does; don't re-derive the split inline — and propose shrinking the memory passage to
-a pointer once promoted, matching the signpost pattern used everywhere else in this repo's docs.
-
-Stay conservative, the same "quiet on noise" bar as every other check here: don't flag a claim just
-because it's durable — it has to be general-audience _and_ absent from README/AGENTS.md/docs.
+Stay conservative, the same "quiet on noise" bar as every other check here: don't flag a claim
+just because it's durable — it has to be general-audience _and_ absent from
+README/AGENTS.md/docs.
 
 ## Report
 
@@ -171,7 +174,7 @@ No edits made — this is a proposal only.
 
 (ranked, or "None found.")
 
-## Broken index
+## Broken graph
 
 (ranked, or "None found.")
 
@@ -186,6 +189,6 @@ No edits made — this is a proposal only.
 No edits made — this is a proposal only.
 ```
 
-Each item is self-contained: what's wrong, where (file + quote), and a proposed direction — a
-suggestion, not a diff, since this skill cannot write. Applying any fix, and committing the result
-through the normal `chore(claude): sync <agent> memory` flow, stays a human call.
+Each item is self-contained: what's wrong, where (entity name + quoted observation), and a
+proposed direction — a suggestion, not a diff, since this skill cannot write. Applying any fix
+happens through the agent's own `mcp__memory` tools in a later session, and stays a human call.

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -9,7 +9,8 @@ description: >-
   anything. Use when asked to audit, review, or check agent/backlog-manager memory for stale
   pointers, restated issue status, orphaned entities, entities that have outgrown one topic, or
   memory content that should live in repo docs instead. The detection backstop to the write-time
-  contract in `backlog-manager.md`. Read-only — never invoke it to apply a fix.
+  contract in carpet-stain/dotfiles's `claude/agents/backlog-manager.md`. Read-only — never invoke
+  it to apply a fix.
 allowed-tools: Read, Glob, Grep, Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh search issues:*), Bash(gh label list:*), Bash(jq:*)
 disallowed-tools: Write, Edit
 ---
@@ -17,16 +18,17 @@ disallowed-tools: Write, Edit
 # Audit Memory
 
 Read-only audit of backlog-manager's knowledge-graph memory — the detection half of keeping that
-memory honest, paired with the write-time pointer-layer contract in `backlog-manager.md`
-(prevention; ADR-0036 owns the model). Sibling to `audit-rules`: same propose-don't-apply
-contract, same report shape, a different target. Report findings and proposed fixes — never edit
-anything.
+memory honest, paired with the write-time pointer-layer contract in carpet-stain/dotfiles's
+`claude/agents/backlog-manager.md` (prevention; carpet-stain/dotfiles ADR-0036 owns the model).
+Sibling to `audit-rules`: same propose-don't-apply contract, same report shape, a different
+target. Report findings and proposed fixes — never edit anything.
 
 **The auditor is not the author.** This runs as its own skill precisely so the actor that writes
 memory doesn't grade its own work — a deliberate independent read, the same reason `audit-rules`
 exists as a separate pass. Don't invoke it _as_ the backlog-manager — and since a skill runs in
 its caller's context, a session that wrote memory runs it via a **fresh-context subagent**
-pointed at this file, never inline (the sanctioned pattern per #412's spike decision).
+pointed at this file, never inline (the sanctioned pattern per carpet-stain/dotfiles#412's spike
+decision).
 
 **On the read-only guarantee.** `disallowed-tools` blocks Write/Edit; the store is read as a
 plain file (Read/jq), never through the `mcp__memory` write-capable tools; and Bash is scoped in
@@ -41,7 +43,8 @@ don't do it.
 Audit the machine-global store `~/.claude/agent-memory-mcp/backlog-manager.jsonl` — one JSONL
 file, one record per line: `{"type":"entity","name":...,"entityType":...,"observations":[...]}`
 or `{"type":"relation","from":...,"to":...,"relationType":...}`. Read it directly (Read or jq);
-it is deliberately human-readable (ADR-0036). If the file is missing or empty, say so and stop —
+it is deliberately human-readable (carpet-stain/dotfiles ADR-0036). If the file is missing or
+empty, say so and stop —
 "no graph memory on this machine," not a pile of empty findings.
 
 The graph spans every repo. Repo scoping is relational: `repo-map` entities name the repos;
@@ -124,7 +127,8 @@ The doc↔memory sibling of `audit-rules`' Cross-doc replication check: content 
 that belongs in a durable documentation home — README, AGENTS.md, or an ADR — rather than in
 memory, because it's general repo documentation, not backlog-manager-audience material, and
 isn't already stated in README.md/AGENTS.md/docs. The spec for what memory may hold at all is
-the pointer-layer contract (ADR-0033, carried into ADR-0036); this check is its lint.
+the pointer-layer contract (carpet-stain/dotfiles ADR-0033, carried into ADR-0036); this check is
+its lint.
 
 Two boundaries, fixed deliberately:
 

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -3,7 +3,8 @@ name: audit-memory
 description: >-
   Read-only audit of a repo's subagent project-memory (`.claude/agent-memory/<name>/`) for
   staleness against live GitHub state, one-home duplication of issue content, a drifted MEMORY.md
-  index, sprawl, and durable content that belongs in README/AGENTS.md/docs instead — reporting
+  index, sprawl, and durable content that belongs in a durable documentation home
+  (README/AGENTS.md/ADR) instead — reporting
   proposed fixes without editing anything. Use when asked to audit, review, or check
   agent/backlog-manager memory for stale pointers, restated issue status, orphaned or dangling
   memory files, files that have grown too long, or memory content that should live in repo docs
@@ -110,8 +111,18 @@ Same shapes as `audit-rules`, calibrated for memory:
 ## Misplaced durable content
 
 The doc↔memory sibling of `audit-rules`' Cross-doc replication check: content sitting in memory
-that's actually general repo documentation, not backlog-manager-audience material, and isn't
-already stated in README.md/AGENTS.md/docs.
+that belongs in a durable documentation home — README, AGENTS.md, or an ADR — rather than in
+memory, because it's general repo documentation, not backlog-manager-audience material, and isn't
+already stated in README.md/AGENTS.md/docs. The spec for what memory may hold at all is ADR-0033
+(memory is a pointer layer, keyed to the frontmatter types); this check is its lint.
+
+Two boundaries, fixed deliberately:
+
+- The Scope section's `adr/` read-exclusion stands even though an ADR is now a named promotion
+  target: ADR is a _proposal target_, never a read-surface for de-dup suppression. Promotion
+  leaves only a pointer in memory, so there's nothing left to false-positive on.
+- **"The issue" is not a promotion target for this check.** Memory↔issue traffic is already owned
+  by the Staleness and One-home checks above; this check stays the doc↔memory sibling.
 
 **Scope**: `project`- and `reference`-type entries only — check each file's `metadata: type:`
 frontmatter. Skip `user`- and `feedback`-type entries outright; they're about how to work with the

--- a/skills/audit-memory/SKILL.md
+++ b/skills/audit-memory/SKILL.md
@@ -23,7 +23,9 @@ same report shape, a different target. Report findings and proposed fixes — ne
 
 **The auditor is not the author.** This runs as its own skill precisely so the actor that writes
 memory doesn't grade its own work — a deliberate independent read, the same reason `audit-rules`
-exists as a separate pass. Don't invoke it _as_ the backlog-manager.
+exists as a separate pass. Don't invoke it _as_ the backlog-manager — and since a skill runs in
+its caller's context, a session that wrote memory runs it via a **fresh-context subagent**
+pointed at this file, never inline (the sanctioned pattern per #412's spike decision).
 
 **On the read-only guarantee.** `disallowed-tools` blocks Write/Edit, and Bash is scoped in
 `allowed-tools` to read-only `gh` queries (`view`/`list`/`search`, `label list`). That's a

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -2,10 +2,12 @@
 name: audit-rules
 description: >-
   Audits the global Claude Code agent-config rules tree ($CLAUDE_CONFIG_DIR/rules) for
-  contradictions and topic/length sprawl, reporting proposed fixes without editing anything.
+  contradictions and topic/length sprawl, and checks AGENTS.md/README.md/docs for content
+  substantially duplicated across them, reporting proposed fixes without editing anything.
   Use when asked to audit, review, or check claude/rules for contradictions, conflicting
-  directives, or files that have grown too long or cover more than one topic. Read-only —
-  never invoke this to apply a fix, only to find issues.
+  directives, files that have grown too long or cover more than one topic, or repo docs
+  that restate the same content in more than one place. Read-only — never invoke this to
+  apply a fix, only to find issues.
 argument-hint: "[path]"
 allowed-tools: Read, Glob, Grep
 disallowed-tools: Write, Edit
@@ -14,9 +16,11 @@ disallowed-tools: Write, Edit
 # Audit Rules
 
 Read-only audit of the global agent-config rules tree for the two maintenance issues the
-removal test cares about: contradictions and sprawl. Report findings and proposed fixes —
-never edit anything yourself. `disallowed-tools` already blocks Write/Edit structurally; treat
-that as a guarantee, not just a reminder.
+removal test cares about: contradictions and sprawl. Also checks this repo's own docs
+(AGENTS.md/README.md/docs) for content replicated across them — a doc↔doc instance of the same
+single-source-of-truth problem, and a named cause of sprawl. Report findings and proposed
+fixes — never edit anything yourself. `disallowed-tools` already blocks Write/Edit
+structurally; treat that as a guarantee, not just a reminder.
 
 ## Scope
 
@@ -27,8 +31,10 @@ from any repo where the rules are deployed.
 If invoked with a path argument, scope the audit to that file or directory instead of the whole
 tree (useful mid-edit on a single file). Otherwise audit everything.
 
-Also read the current repo's own `AGENTS.md` and any `docs/*.md`, if present — needed for the
-local-doc contradiction check below and the AGENTS.md length check under Sprawl.
+Also read the current repo's own `AGENTS.md`, `README.md`, and any top-level `docs/*.md`
+(not nested subdirectories — see Cross-doc replication check's scope note), if present — needed
+for the local-doc contradiction check below, the AGENTS.md length check under Sprawl, and the
+Cross-doc replication check.
 
 ## Contradiction check
 
@@ -84,6 +90,40 @@ detail itself is the target.
 Each finding quotes the restating prose and the enforcing config, and proposes the pointer-form
 rewrite — same format as the Contradictions check, this is not a new report shape.
 
+## Cross-doc replication check
+
+Issue #140's restated-enforcement check is doc↔config: prose restating a spec a config already
+enforces. This check is the doc↔doc sibling — same single-source-of-truth violation, different
+pair: substantial content restated across AGENTS.md, README.md, and top-level `docs/*.md`
+instead of living in exactly one and being pointed at from the others. Unpruned replication
+between these is a named top cause of AGENTS.md's length problem (#178) — this check names
+which content to cut, length only measures the symptom.
+
+**Substantial** means a full sentence, list item, or table row making the same claim with the
+same specifics (not just both docs mentioning "XDG" or "Homebrew") — near-verbatim wording isn't
+required, same claim/same specifics is what makes it substantial. A shared proper noun, tool
+name, or one-line cross-reference is not substantial; don't flag those. If in doubt whether a
+match clears the bar, don't report it — this check should stay quiet on noise, not cry wolf on
+every shared word.
+
+For each substantial match:
+
+- Quote both locations (file + the specific passage) side by side.
+- Propose which doc should own it and which should point instead of restate. Use this repo's own
+  ownership split if a "one home per fact" doc-home-map exists (check for it — AGENTS.md may
+  define one); absent that, default to the shape both README.md and AGENTS.md already state for
+  themselves in this repo: README is the front door (what this is, why, install, use), AGENTS.md
+  is how to work here. Don't invent or restate that split yourself if the repo already states it
+  somewhere — point at wherever it's defined instead of re-deriving it inline in the report.
+- Suggest the pointer-form replacement in the doc that should stop restating (a one-line
+  cross-reference), not a full rewrite — same "propose, don't diff" limit as the other checks.
+
+Scope stays to the docs an agent relies on for context — AGENTS.md, README.md, top-level
+`docs/*.md` — not general repo-doc linting. Don't descend into `docs/` subdirectories (e.g. an
+`adr/` archive of point-in-time decisions is expected to reference or echo AGENTS.md/README
+content by nature, not drift by accident) and don't extend this check to CHANGELOG.md,
+per-tool READMEs, or code comments.
+
 ## Report
 
 Emit one structured markdown report directly in this response:
@@ -102,6 +142,10 @@ No edits made — this is a proposal only.
 (ranked, or "None found.")
 
 ## Restated enforcement
+
+(ranked, or "None found.")
+
+## Cross-doc replication
 
 (ranked, or "None found.")
 

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -33,7 +33,9 @@ tree (useful mid-edit on a single file). Otherwise audit everything.
 Also read the current repo's own `AGENTS.md`, `README.md`, and any top-level `docs/*.md`
 (not nested subdirectories — see Cross-doc replication check's scope note), if present — needed
 for the local-doc contradiction check below, the AGENTS.md length check under Sprawl, and the
-Cross-doc replication check.
+Cross-doc replication check. If the repo uses a _real_ `CLAUDE.md` (not a symlink to `AGENTS.md`)
+as its canonical agent doc, read that too and treat it as the subject wherever these checks say
+`AGENTS.md` — a `CLAUDE.md` symlink resolves to `AGENTS.md`, so read it once, not twice.
 
 ## Contradiction check
 
@@ -43,10 +45,14 @@ Read every file in scope fully, then look for:
   token cost" contradiction in this repo is the worked example of this shape.
 - **Cross-file**: two rules files disagreeing — e.g. a `universal/` file and a `tools/` file
   recommending opposite defaults.
-- **Local-doc drift**: the repo's own `AGENTS.md`/`docs/` disagreeing with a rules file. This is
-  _expected and fine_ under LOCAL-WINS when the local doc clearly overrides the point on
-  purpose — only flag it when it reads like accidental drift instead of a deliberate override
-  (e.g. the local doc doesn't acknowledge it's overriding anything, it just quietly contradicts).
+- **Local-doc drift**: the repo's own `AGENTS.md` (or a real `CLAUDE.md`) / `docs/` disagreeing
+  with a rules file. Under LOCAL-WINS a contradiction is _allowed_ — the repo wins — so the target
+  is _accidental drift_, not deliberate override, and the signal is a marker, not tone. A section
+  carrying `> Overrides **<rule>.md** § … — reason: …` (the marker `compose-agents` writes when a
+  human confirms an override) is a settled departure: skip it. Flag an _unmarked_ contradiction,
+  and propose the resolution — either adopt the rule's semantics, or record the override by adding
+  that marker so it stops reading as accidental and both this check and `compose-agents` stop
+  re-flagging it.
 
 Report most-confident first. Each finding quotes both locations (file path + the specific
 sentence) and states plainly why they conflict.

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -57,6 +57,26 @@ Two independent signals, both worth checking on every file in scope:
   judgment from reading the content, not a heading-count metric — the precedent is
   `philosophy.md` splitting into the four `universal/` files once it outgrew a single topic.
 
+## Restated-enforcement check
+
+AGENTS.md (or a rules file) should point at a config that already enforces something, not
+restate the config's exact detail as prose — the same signpost-vs-spec distinction
+`compose-agents` now applies when instantiating (see its "Pointer-form for enforced specs"
+step). Flag prose in scope that enumerates an exact, mechanically-checkable value — a literal
+list of allowed values, a regex, a numeric threshold — that a config file present in the current
+repo already defines byte-for-byte. The Conventional-Commit type list restated in prose when a
+CI workflow's regex already enforces it (this repo's own `pr-guards.yml` is the worked example)
+is the shape to look for; a lint-rule-code list restated when a linter config already lists them
+is the same shape.
+
+Don't flag workflow _shape_ (step ordering, when to squash, when to open a PR) even when a slow
+or CI-only gate enforces it — that's guidance no config can teach ahead of time, not a duplicated
+spec, and removing it would just push discovery to the most expensive point. Only the enumerable
+detail itself is the target.
+
+Each finding quotes the restating prose and the enforcing config, and proposes the pointer-form
+rewrite — same format as the Contradictions check, this is not a new report shape.
+
 ## Report
 
 Emit one structured markdown report directly in this response:
@@ -71,6 +91,10 @@ No edits made — this is a proposal only.
 (ranked most-confident first, or "None found.")
 
 ## Sprawl
+
+(ranked, or "None found.")
+
+## Restated enforcement
 
 (ranked, or "None found.")
 

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -28,7 +28,7 @@ If invoked with a path argument, scope the audit to that file or directory inste
 tree (useful mid-edit on a single file). Otherwise audit everything.
 
 Also read the current repo's own `AGENTS.md` and any `docs/*.md`, if present — needed for the
-local-doc contradiction check below.
+local-doc contradiction check below and the AGENTS.md length check under Sprawl.
 
 ## Contradiction check
 
@@ -48,7 +48,7 @@ sentence) and states plainly why they conflict.
 
 ## Sprawl check
 
-Two independent signals, both worth checking on every file in scope:
+**Rules tree** (`rules/**`) gets two independent signals:
 
 - **Length**: files over ~200 lines — the threshold `claude/README.md`'s own "Why the rule
   files are terse" section names. The Read tool's line-numbered output gives you the count for
@@ -56,6 +56,13 @@ Two independent signals, both worth checking on every file in scope:
 - **Topic span**: does the file cover more than one coherent topic? This is a qualitative
   judgment from reading the content, not a heading-count metric — the precedent is
   `philosophy.md` splitting into the four `universal/` files once it outgrew a single topic.
+
+**AGENTS.md and `docs/*.md`** get a length-only check, against the separate, higher threshold
+`claude/README.md`'s "Why the rule files are terse" section names for composed per-repo guides
+(soft-warn / firm-flag). Don't flag topic span there — spanning many topics is AGENTS.md's job.
+When a file crosses the threshold, don't just report "too long": check it against the
+Restated-enforcement check below and for unpruned topic overlap between its own sections, and
+point at whichever applies as the cause and the pointer-form/de-dup prune as the remedy.
 
 ## Restated-enforcement check
 

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit-rules
 description: >-
-  Audits the global Claude Code agent-config rules tree ($CLAUDE_CONFIG_DIR/rules) for
+  Audits the global Claude Code agent-config rules tree (~/.claude/rules) for
   contradictions and topic/length sprawl, and checks AGENTS.md/README.md/docs for content
   substantially duplicated across them, reporting proposed fixes without editing anything.
   Use when asked to audit, review, or check claude/rules for contradictions, conflicting
@@ -24,9 +24,8 @@ structurally; treat that as a guarantee, not just a reminder.
 
 ## Scope
 
-Read target: `$CLAUDE_CONFIG_DIR/rules/**/*.md`, falling back to `~/.claude/rules` if the env
-var is unset. Never hardcode a specific repo's path (e.g. a dotfiles checkout) — this must work
-from any repo where the rules are deployed.
+Read target: `~/.claude/rules/**/*.md`. Never hardcode a specific repo's path (e.g. a
+dotfiles checkout) — this must work from any repo where the rules are deployed.
 
 If invoked with a path argument, scope the audit to that file or directory instead of the whole
 tree (useful mid-edit on a single file). Otherwise audit everything.

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -70,6 +70,44 @@ When a file crosses the threshold, don't just report "too long": check it agains
 Restated-enforcement check below and for unpruned topic overlap between its own sections, and
 point at whichever applies as the cause and the pointer-form/de-dup prune as the remedy.
 
+### Sprawl reduction playbook (AGENTS.md over threshold)
+
+"Too long" alone re-derives the same menu every run. Once a cause above applies, propose cuts
+in this order — each is a strategy that actually shrank a doc in this repo's own history,
+highest-confidence first:
+
+1. **Signpost + link.** A section re-explaining content another doc owns collapses to a 1-3
+   line essence plus a pointer (`see README.md § ...`, or this repo's doc-home-map if one
+   exists). Verify the target doc actually covers it before cutting toward it — pointing at a
+   doc that doesn't hold the material loses the content, it doesn't relocate it. De-duping
+   AGENTS.md against README this way (philosophy list, XDG principle, structure blurb, each
+   folded to a pointer) took one repo's copy 318 → 305 lines in a single pass.
+2. **Drop restated-enforcement.** Prose spelling out an exact value a config already enforces
+   (a CI regex's allowed-type list, a linter's rule codes) is the Restated-enforcement check's
+   target — cut it there, not just here. The same instinct, applied across this repo's whole
+   rules tree, was the largest single trim on record: 574 → 360 lines (-37%), no directive lost.
+3. **Cut restated-principle sections.** A repo-local section that just re-lists an
+   always-loaded `rules/universal/*` principle is pure duplication — the universal rule applies
+   every session regardless of whether AGENTS.md repeats it. Keep only the repo-specific slice
+   (e.g. which doc owns which fact); drop the generic restatement.
+4. **Collapse intra-file overlap.** Two sections echoing the same point (a checklist repeated
+   in two places, a rule stated once under "editing" and again under "git workflow") merge into
+   one, cross-referenced from where the other used to be.
+5. **Titles over prose.** For an enumerated list, keep the scannable numbered heading plus one
+   pointer to the doc that owns the reasoning; cut the per-item explanatory paragraph. Merging
+   redundant "why" sections this way took this repo's own `claude/README.md` from 326 → 265
+   lines with no content lost.
+6. **Merge duplicate command blocks.** Near-identical fenced command examples collapse to one.
+7. **Fix source-of-truth direction.** If AGENTS.md holds mechanics another doc should own, move
+   the mechanics there and have AGENTS.md point — don't just trim in place. Watch for the
+   circular-pointer trap: the two docs must not each say "see the other."
+
+**The honest floor.** After exhausting 1-7, the remainder is legitimate unique agent content
+(layer map, source-of-truth map, failure-stage semantics) already at essence-plus-pointer —
+don't force it thinner by externalizing high-value content behind an extra hop just to clear
+the firm-flag. Report "restatement and overlap eliminated; residual N lines are unique
+content," not "still over threshold, keep cutting."
+
 ## Restated-enforcement check
 
 AGENTS.md (or a rules file) should point at a config that already enforces something, not

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -30,10 +30,11 @@ dotfiles checkout) — this must work from any repo where the rules are deployed
 If invoked with a path argument, scope the audit to that file or directory instead of the whole
 tree (useful mid-edit on a single file). Otherwise audit everything.
 
-Also read the current repo's own `AGENTS.md`, `README.md`, and any top-level `docs/*.md`
-(not nested subdirectories — see Cross-doc replication check's scope note), if present — needed
-for the local-doc contradiction check below, the AGENTS.md length check under Sprawl, and the
-Cross-doc replication check. If the repo uses a _real_ `CLAUDE.md` (not a symlink to `AGENTS.md`)
+Always read the current repo's own `AGENTS.md` and `README.md` when they exist, plus any
+top-level `docs/*.md` (not nested subdirectories — see Cross-doc replication check's scope note).
+These aren't optional context: the local-doc contradiction check below, the AGENTS.md length
+check under Sprawl, and the Cross-doc replication check all depend on them, and none may silently
+skip `README.md` when it's present. If the repo uses a _real_ `CLAUDE.md` (not a symlink to `AGENTS.md`)
 as its canonical agent doc, read that too and treat it as the subject wherever these checks say
 `AGENTS.md` — a `CLAUDE.md` symlink resolves to `AGENTS.md`, so read it once, not twice.
 
@@ -160,6 +161,21 @@ For each substantial match:
   somewhere — point at wherever it's defined instead of re-deriving it inline in the report.
 - Suggest the pointer-form replacement in the doc that should stop restating (a one-line
   cross-reference), not a full rewrite — same "propose, don't diff" limit as the other checks.
+
+**Circular pointers are a first-class finding here, independent of length.** Two docs that each
+say "see the other" for the same fact — so it lives in neither — are the doc↔doc dual of the
+duplication above; flag them the same way, quoting both pointers. The Sprawl playbook names this
+trap too (step 7), but only inside the AGENTS.md-over-threshold path, so a circular pointer
+between two _short_ docs would otherwise slip through. It's just as broken at any length, so it's
+caught here regardless of either doc's size.
+
+**Stale issue-ref an ADR now owns.** Once a decision has an ADR (`docs/adr/NNNN-*.md`), later
+docs should cite the ADR (`see docs/adr/0003-…md`), not the originating issue — the doc-home
+map's rule as ADRs accumulate. Flag a `#N` pointer used to _justify a settled decision_ when an
+ADR covering that decision exists, and propose repointing it at the ADR. Stay conservative: a
+`#N` referencing live or tracking work (an open issue, a follow-up, a bug still in flight) is
+fine and must not be flagged — only a decision's why-pointer that an ADR now owns is the target,
+same "quiet on noise" bar as the duplication check. These report under Cross-doc replication too.
 
 Scope stays to the docs an agent relies on for context — AGENTS.md, README.md, top-level
 `docs/*.md` — not general repo-doc linting. Don't descend into `docs/` subdirectories (e.g. an

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: audit-rules
+description: >-
+  Audits the global Claude Code agent-config rules tree ($CLAUDE_CONFIG_DIR/rules) for
+  contradictions and topic/length sprawl, reporting proposed fixes without editing anything.
+  Use when asked to audit, review, or check claude/rules for contradictions, conflicting
+  directives, or files that have grown too long or cover more than one topic. Read-only —
+  never invoke this to apply a fix, only to find issues.
+argument-hint: "[path]"
+allowed-tools: Read, Glob, Grep
+disallowed-tools: Write, Edit
+---
+
+# Audit Rules
+
+Read-only audit of the global agent-config rules tree for the two maintenance issues the
+removal test cares about: contradictions and sprawl. Report findings and proposed fixes —
+never edit anything yourself. `disallowed-tools` already blocks Write/Edit structurally; treat
+that as a guarantee, not just a reminder.
+
+## Scope
+
+Read target: `$CLAUDE_CONFIG_DIR/rules/**/*.md`, falling back to `~/.claude/rules` if the env
+var is unset. Never hardcode a specific repo's path (e.g. a dotfiles checkout) — this must work
+from any repo where the rules are deployed.
+
+If invoked with a path argument, scope the audit to that file or directory instead of the whole
+tree (useful mid-edit on a single file). Otherwise audit everything.
+
+Also read the current repo's own `AGENTS.md` and any `docs/*.md`, if present — needed for the
+local-doc contradiction check below.
+
+## Contradiction check
+
+Read every file in scope fully, then look for:
+
+- **Within-file**: a file asserting X in one section and not-X in another. The #106 "negligible
+  token cost" contradiction in this repo is the worked example of this shape.
+- **Cross-file**: two rules files disagreeing — e.g. a `universal/` file and a `tools/` file
+  recommending opposite defaults.
+- **Local-doc drift**: the repo's own `AGENTS.md`/`docs/` disagreeing with a rules file. This is
+  _expected and fine_ under LOCAL-WINS when the local doc clearly overrides the point on
+  purpose — only flag it when it reads like accidental drift instead of a deliberate override
+  (e.g. the local doc doesn't acknowledge it's overriding anything, it just quietly contradicts).
+
+Report most-confident first. Each finding quotes both locations (file path + the specific
+sentence) and states plainly why they conflict.
+
+## Sprawl check
+
+Two independent signals, both worth checking on every file in scope:
+
+- **Length**: files over ~200 lines — the threshold `claude/README.md`'s own "Why the rule
+  files are terse" section names. The Read tool's line-numbered output gives you the count for
+  free; no need to shell out.
+- **Topic span**: does the file cover more than one coherent topic? This is a qualitative
+  judgment from reading the content, not a heading-count metric — the precedent is
+  `philosophy.md` splitting into the four `universal/` files once it outgrew a single topic.
+
+## Report
+
+Emit one structured markdown report directly in this response:
+
+```markdown
+# Rules Audit
+
+No edits made — this is a proposal only.
+
+## Contradictions
+
+(ranked most-confident first, or "None found.")
+
+## Sprawl
+
+(ranked, or "None found.")
+
+No edits made — this is a proposal only.
+```
+
+Each item is self-contained: what's wrong, where (file + quote), and a proposed direction to
+resolve it — a suggestion, not a diff, since this skill cannot write.
+
+## Non-goals
+
+The two maintenance judgment gates from `claude/README.md`'s "Maintenance discipline" —
+_add a rule only after it would have prevented an actual mistake_, and _remove a rule once it's
+followed without being told_ — stay human calls. Don't attempt to apply either; this skill only
+surfaces contradictions and sprawl for a human to weigh.

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Audits the global Claude Code agent-config rules tree (~/.claude/rules) for
   contradictions and topic/length sprawl, and checks AGENTS.md/README.md/docs for content
   substantially duplicated across them, reporting proposed fixes without editing anything.
-  Use when asked to audit, review, or check claude/rules for contradictions, conflicting
+  Use when asked to audit, review, or check the rules tree for contradictions, conflicting
   directives, files that have grown too long or cover more than one topic, or repo docs
   that restate the same content in more than one place. Read-only — never invoke this to
   apply a fix, only to find issues.
@@ -42,8 +42,8 @@ as its canonical agent doc, read that too and treat it as the subject wherever t
 
 Read every file in scope fully, then look for:
 
-- **Within-file**: a file asserting X in one section and not-X in another. The #106 "negligible
-  token cost" contradiction in this repo is the worked example of this shape.
+- **Within-file**: a file asserting X in one section and not-X in another — e.g. a file that
+  argues a cost is negligible in one section, then treats the same cost as significant elsewhere.
 - **Cross-file**: two rules files disagreeing — e.g. a `universal/` file and a `tools/` file
   recommending opposite defaults.
 - **Local-doc drift**: the repo's own `AGENTS.md` (or a real `CLAUDE.md`) / `docs/` disagreeing
@@ -62,7 +62,7 @@ sentence) and states plainly why they conflict.
 
 **Rules tree** (`rules/**`) gets two independent signals:
 
-- **Length**: files over ~200 lines — the threshold `claude/README.md`'s own "Why the rule
+- **Length**: files over ~200 lines — the threshold `README.md`'s own "Why the rule
   files are terse" section names. The Read tool's line-numbered output gives you the count for
   free; no need to shell out.
 - **Topic span**: does the file cover more than one coherent topic? This is a qualitative
@@ -70,7 +70,7 @@ sentence) and states plainly why they conflict.
   `philosophy.md` splitting into the four `universal/` files once it outgrew a single topic.
 
 **AGENTS.md and `docs/*.md`** get a length-only check, against the separate, higher threshold
-`claude/README.md`'s "Why the rule files are terse" section names for composed per-repo guides
+`README.md`'s "Why the rule files are terse" section names for composed per-repo guides
 (soft-warn / firm-flag). Don't flag topic span there — spanning many topics is AGENTS.md's job.
 When a file crosses the threshold, don't just report "too long": check it against the
 Restated-enforcement check below and for unpruned topic overlap between its own sections, and
@@ -79,19 +79,16 @@ point at whichever applies as the cause and the pointer-form/de-dup prune as the
 ### Sprawl reduction playbook (AGENTS.md over threshold)
 
 "Too long" alone re-derives the same menu every run. Once a cause above applies, propose cuts
-in this order — each is a strategy that actually shrank a doc in this repo's own history,
-highest-confidence first:
+in this order, highest-confidence first:
 
 1. **Signpost + link.** A section re-explaining content another doc owns collapses to a 1-3
    line essence plus a pointer (`see README.md § ...`, or this repo's doc-home-map if one
    exists). Verify the target doc actually covers it before cutting toward it — pointing at a
-   doc that doesn't hold the material loses the content, it doesn't relocate it. De-duping
-   AGENTS.md against README this way (philosophy list, XDG principle, structure blurb, each
-   folded to a pointer) took one repo's copy 318 → 305 lines in a single pass.
+   doc that doesn't hold the material loses the content, it doesn't relocate it.
 2. **Drop restated-enforcement.** Prose spelling out an exact value a config already enforces
    (a CI regex's allowed-type list, a linter's rule codes) is the Restated-enforcement check's
-   target — cut it there, not just here. The same instinct, applied across this repo's whole
-   rules tree, was the largest single trim on record: 574 → 360 lines (-37%), no directive lost.
+   target — cut it there, not just here. Applied across a whole rules tree, this is usually the
+   largest single trim available, since enumerable specs tend to accrete in prose over time.
 3. **Cut restated-principle sections.** A repo-local section that just re-lists an
    always-loaded `rules/universal/*` principle is pure duplication — the universal rule applies
    every session regardless of whether AGENTS.md repeats it. Keep only the repo-specific slice
@@ -100,9 +97,7 @@ highest-confidence first:
    in two places, a rule stated once under "editing" and again under "git workflow") merge into
    one, cross-referenced from where the other used to be.
 5. **Titles over prose.** For an enumerated list, keep the scannable numbered heading plus one
-   pointer to the doc that owns the reasoning; cut the per-item explanatory paragraph. Merging
-   redundant "why" sections this way took this repo's own `claude/README.md` from 326 → 265
-   lines with no content lost.
+   pointer to the doc that owns the reasoning; cut the per-item explanatory paragraph.
 6. **Merge duplicate command blocks.** Near-identical fenced command examples collapse to one.
 7. **Fix source-of-truth direction.** If AGENTS.md holds mechanics another doc should own, move
    the mechanics there and have AGENTS.md point — don't just trim in place. Watch for the
@@ -121,10 +116,9 @@ restate the config's exact detail as prose — the same signpost-vs-spec distinc
 `compose-agents` now applies when instantiating (see its "Pointer-form for enforced specs"
 step). Flag prose in scope that enumerates an exact, mechanically-checkable value — a literal
 list of allowed values, a regex, a numeric threshold — that a config file present in the current
-repo already defines byte-for-byte. The Conventional-Commit type list restated in prose when a
-CI workflow's regex already enforces it (this repo's own `pr-guards.yml` is the worked example)
-is the shape to look for; a lint-rule-code list restated when a linter config already lists them
-is the same shape.
+repo already defines byte-for-byte. A Conventional-Commit type list restated in prose when a CI
+workflow's regex already enforces it is the shape to look for; a lint-rule-code list restated
+when a linter config already lists them is the same shape.
 
 Don't flag workflow _shape_ (step ordering, when to squash, when to open a PR) even when a slow
 or CI-only gate enforces it — that's guidance no config can teach ahead of time, not a duplicated
@@ -136,11 +130,12 @@ rewrite — same format as the Contradictions check, this is not a new report sh
 
 ## Cross-doc replication check
 
-Issue #140's restated-enforcement check is doc↔config: prose restating a spec a config already
-enforces. This check is the doc↔doc sibling — same single-source-of-truth violation, different
-pair: substantial content restated across AGENTS.md, README.md, and top-level `docs/*.md`
-instead of living in exactly one and being pointed at from the others. Unpruned replication
-between these is a named top cause of AGENTS.md's length problem (#178) — this check names
+carpet-stain/dotfiles#140's restated-enforcement check is doc↔config: prose restating a spec a
+config already enforces. This check is the doc↔doc sibling — same single-source-of-truth
+violation, different pair: substantial content restated across AGENTS.md, README.md, and
+top-level `docs/*.md` instead of living in exactly one and being pointed at from the others.
+Unpruned replication between these is a named top cause of AGENTS.md's length problem
+(carpet-stain/dotfiles#178) — this check names
 which content to cut, length only measures the symptom.
 
 **Substantial** means a full sentence, list item, or table row making the same claim with the
@@ -216,7 +211,7 @@ resolve it — a suggestion, not a diff, since this skill cannot write.
 
 ## Non-goals
 
-The two maintenance judgment gates from `claude/README.md`'s "Maintenance discipline" —
+The two maintenance judgment gates from `README.md`'s "Maintenance discipline" —
 _add a rule only after it would have prevented an actual mistake_, and _remove a rule once it's
 followed without being told_ — stay human calls. Don't attempt to apply either; this skill only
 surfaces contradictions and sprawl for a human to weigh.

--- a/skills/compose-agents/SKILL.md
+++ b/skills/compose-agents/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: compose-agents
+description: >-
+  Drafts or updates a repo's AGENTS.md by instantiating the global Claude Code rules tree
+  ($CLAUDE_CONFIG_DIR/rules) with this repo's detected facts (branch model, version scheme,
+  scopes, pre-commit tooling, credential pattern), following each rule file's COMPOSE block.
+  Use when asked to scaffold AGENTS.md, set up agent config for this repo, compose or
+  instantiate the rules into a repo doc, or check whether an existing AGENTS.md has drifted
+  from the abstract rules. Never creates or edits AGENTS.md directly — always presents a full
+  draft or diff in chat and waits for explicit approval before any file is written.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Compose Agents
+
+Instantiates the global agent-config rules tree into this repo's `AGENTS.md`. Operates on the
+current working directory only — like `/init`, not a skill for scaffolding some other repo by
+path.
+
+**This skill never writes `AGENTS.md` itself.** `Write`/`Edit` aren't in its `allowed-tools` for
+a reason it can't route around: assemble the full draft or diff, present it in this response,
+and stop. Only create or update the file after the user has replied approving it in this same
+conversation — a later, ordinary turn, not this skill continuing on its own. Don't shell out via
+`Bash` (e.g. a `cat > AGENTS.md` heredoc) to work around the missing Write/Edit access — that
+would defeat the whole point of the restriction.
+
+## Step 1 — mode detection
+
+Check whether `AGENTS.md` already exists at the repo root. This branches everything below into
+two different code paths, not the same check run twice:
+
+- **Draft mode** (no `AGENTS.md`): build a full instantiation from scratch.
+- **Suggest-diff mode** (`AGENTS.md` exists): never re-distill a mature repo's doc back into the
+  abstract rules — that direction is the design's cardinal rule. Only compare the
+  mechanically-instantiated sections (identifiable by their "Concrete realization of X"
+  blockquote lineage line — see Step 4) against freshly detected facts, and propose a diff.
+  Repo-domain sections (anything without that lineage line) are never touched or regenerated —
+  report them as "exists, not reviewed."
+
+## Step 2 — run the detector
+
+Run `${CLAUDE_SKILL_DIR}/scripts/detect.sh` via Bash from the repo root and parse its `KEY=value`
+output. It's read-only and best-effort per field — a missing tool or unmet precondition blanks
+only that field, not the rest. Treat `BRANCH_MODEL` specifically as an inferred guess, not a
+fact — its own output says so — and present it to the user as "detected, please confirm" rather
+than asserting it.
+
+## Step 3 — read the applicable rule files
+
+GATE-select by the detected facts: `git.md` always (its own GATE is a near-tautology); `github.md`
+only if `REMOTE_HOST=github.com`; `go.md` only if `IS_GO_REPO=true`; any
+`platform/private/*.md` present. Read each file's COMPOSE block (or its whole content, for
+`github.md`, which has none of its own — see Step 4).
+
+## Step 4 — instantiation engine (Draft mode)
+
+Per applicable COMPOSE-bearing file, fill its `<placeholders>` with the detected facts and emit
+its section with two things this repo's own `AGENTS.md` uses as the literal template to match:
+
+- A blockquote lineage line: `> Concrete realization of **git.md** (...) for this repo: ...`
+- The shared "Precedence: this repo's own docs win over the generic files" section, once, near
+  the top of the doc — not repeated per section.
+
+Two traps, both real and both present in this repo's own `AGENTS.md`:
+
+- **`github.md` has no COMPOSE block of its own** ("`git.md` owns everything composable" is
+  literally its own text). Its content folds into the _same_ git.md-derived sections instead of
+  becoming a separate parallel "GitHub section" — this repo's own "Local tooling" and
+  "Credentials" sections each cite both files under one blockquote. Don't emit a
+  `github.md`-only section.
+- **A detected `BRANCH_MODEL` that diverges from git.md's own documented default is a case
+  git.md cannot fill mechanically.** `git.md` only documents one model (long-lived working
+  branch + protected main, squash-merged). If detect.sh's heuristic flags the alternate
+  short-lived-feature-branch signal, don't invent full prose for a model git.md never
+  describes — instantiate git.md's actual documented model as the mechanical baseline, and
+  separately flag to the user: "detected signals suggest this repo may use a different branch
+  model than git.md's default — you'll likely want to hand-write the Git workflow section, the
+  way this pattern's own dotfiles repo does." Honesty about the gap beats a fabricated model.
+
+## Step 5 — repo-domain TODO-skeleton (Draft mode)
+
+For sections with no abstract source — what this repo is, its philosophy, structure &
+conventions, how to verify changes — emit skeleton headers with a one-line prompt each, seeded
+by light, cheap reads (root `README`, package manifests, top-level directory names already in
+`SCOPES`). Explicit `<!-- TODO: ... -->` markers, never invented narrative. This is deliberately
+narrower than `/init`'s full codebase analysis — point the user at `/init` if they want deeper
+codebase-derived drafting of these sections.
+
+Include one `<!-- TODO: name a real exemplar file and a real anti-pattern file for pattern X -->`
+line per notable convention you can identify a pattern for, but don't try to auto-select which
+files qualify — that's a judgment call prone to false positives, left to the human.
+
+## Step 6 — suggest-diff mode
+
+Read the existing `AGENTS.md`. For each mechanically-instantiated section (found by its lineage
+blockquote), recompute what Step 4 would produce today and diff it against what's there. Propose
+only that diff. Do not touch repo-domain sections.
+
+## Step 7 — CLAUDE.md bridge
+
+If `HAS_CLAUDE_MD_SYMLINK` is empty and the repo doesn't already have one, propose (don't create)
+a gitignored `CLAUDE.md → AGENTS.md` symlink at the repo root, matching this repo's own pattern —
+mention it as a suggested follow-up step in the presented draft, not something written now.
+
+## Step 8 — present and wait
+
+Assemble the full draft (Draft mode) or diff (Suggest-diff mode) directly in this response.
+State plainly: "This is a proposal — nothing has been written to disk. Confirm and I'll
+create/update the file." Stop there.
+
+## Not in scope for v1
+
+Two bullets from this skill's epic are deliberately deferred to follow-up issues, not built
+here: auto-_detecting_ exemplar/anti-pattern files (the TODO-prompt version in Step 5 is the
+cheap in-scope substitute), and translating permission-like prose into `settings.json`
+allow/deny entries (genuinely underspecified — real scope creep for a first version).

--- a/skills/compose-agents/SKILL.md
+++ b/skills/compose-agents/SKILL.md
@@ -2,7 +2,7 @@
 name: compose-agents
 description: >-
   Drafts or updates a repo's AGENTS.md by instantiating the global Claude Code rules tree
-  ($CLAUDE_CONFIG_DIR/rules) with this repo's detected facts (branch model, version scheme,
+  (~/.claude/rules) with this repo's detected facts (branch model, version scheme,
   scopes, pre-commit tooling, credential pattern), following each rule file's COMPOSE block.
   Use when asked to scaffold AGENTS.md, set up agent config for this repo, compose or
   instantiate the rules into a repo doc, or check whether an existing AGENTS.md has drifted

--- a/skills/compose-agents/SKILL.md
+++ b/skills/compose-agents/SKILL.md
@@ -68,14 +68,17 @@ Two traps, both real and both present in this repo's own `AGENTS.md`:
   becoming a separate parallel "GitHub section" — this repo's own "Local tooling" and
   "Credentials" sections each cite both files under one blockquote. Don't emit a
   `github.md`-only section.
-- **A detected `BRANCH_MODEL` that diverges from git.md's own documented default is a case
-  git.md cannot fill mechanically.** `git.md` only documents one model (long-lived working
-  branch + protected main, squash-merged). If detect.sh's heuristic flags the alternate
-  short-lived-feature-branch signal, don't invent full prose for a model git.md never
-  describes — instantiate git.md's actual documented model as the mechanical baseline, and
-  separately flag to the user: "detected signals suggest this repo may use a different branch
-  model than git.md's default — you'll likely want to hand-write the Git workflow section, the
-  way this pattern's own dotfiles repo does." Honesty about the gap beats a fabricated model.
+- **`BRANCH_MODEL` no longer selects between two models — `git.md` documents exactly one.**
+  #128 consolidated `git.md` off its old long-lived-working-branch + squash-merge default onto
+  short-lived-feature-branch + rebase-merge; that's now its only Branch & PR model, fully
+  fillable via `<protected-branch>`. Always instantiate it mechanically regardless of what
+  `detect.sh`'s heuristic finds — the CI signal it looks for (`pr-guards.yml`'s pattern: gating
+  PRs on a single-commit count and a Conventional Commit subject) only affects _confidence_, not
+  which prose to emit. Signal found: the model is CI-enforced here — this repo's own `AGENTS.md`
+  is the worked example, citing `git.md`'s model directly with `pr-guards.yml` as the
+  confirmation. Signal absent: instantiate the same section, but flag to the user that no CI
+  signal confirms enforcement is actually wired up yet, so they should double-check it or wire
+  it up rather than assume the section describes something already enforced.
 
 ### Pointer-form for enforced specs
 

--- a/skills/compose-agents/SKILL.md
+++ b/skills/compose-agents/SKILL.md
@@ -5,9 +5,10 @@ description: >-
   (~/.claude/rules) with this repo's detected facts (branch model, version scheme,
   scopes, pre-commit tooling, credential pattern), following each rule file's COMPOSE block.
   Use when asked to scaffold AGENTS.md, set up agent config for this repo, compose or
-  instantiate the rules into a repo doc, or check whether an existing AGENTS.md has drifted
-  from the abstract rules. Never creates or edits AGENTS.md directly — always presents a full
-  draft or diff in chat and waits for explicit approval before any file is written.
+  instantiate the rules into a repo doc, check whether an existing AGENTS.md has drifted from
+  the abstract rules, or augment a doc that predates the rules with the instantiations it's
+  missing. Never creates or edits AGENTS.md directly — always presents a full draft or diff in
+  chat and waits for explicit approval before any file is written.
 allowed-tools: Read, Glob, Grep, Bash
 ---
 
@@ -26,24 +27,37 @@ would defeat the whole point of the restriction.
 
 ## Step 1 — mode detection
 
-Check whether `AGENTS.md` already exists at the repo root. This branches everything below into
-two different code paths, not the same check run twice:
+Find the repo's canonical agent doc and branch on it, from the detector's two signals (Step 2 —
+run it first if needed): `HAS_AGENTS_MD`, and `HAS_CLAUDE_MD`, which is empty (absent),
+`symlink:<target>` (a symlink, normally to `AGENTS.md`), or `file` (a real file). This yields
+three modes, not one check run twice. `AGENTS.md` is always the target; a
+mature repo's doc is never re-distilled back into the abstract rules — that direction is the
+design's cardinal rule. Repo-domain sections (anything without a lineage line — see Step 4) are
+never touched or regenerated in any mode; report them "exists, not reviewed."
 
-- **Draft mode** (no `AGENTS.md`): build a full instantiation from scratch.
-- **Suggest-diff mode** (`AGENTS.md` exists): never re-distill a mature repo's doc back into the
-  abstract rules — that direction is the design's cardinal rule. Only compare the
-  mechanically-instantiated sections (identifiable by their "Concrete realization of X"
-  blockquote lineage line — see Step 4) against freshly detected facts, and propose a diff.
-  Repo-domain sections (anything without that lineage line) are never touched or regenerated —
-  report them as "exists, not reviewed."
+- **Draft mode** — neither `AGENTS.md` nor a real `CLAUDE.md`. Build a full instantiation from
+  scratch (Steps 4–5).
+- **Update mode** — `AGENTS.md` exists (a `CLAUDE.md` symlink pointing at it is its expected
+  companion, not a second doc). Reconcile it in place (Step 6): diff already-composed sections,
+  augment missing ones, surface contradictions.
+- **Migrate mode** — a _real_ `CLAUDE.md` exists with no `AGENTS.md` (a legacy or
+  non-Claude-tool layout). Never silently draft a parallel `AGENTS.md` beside it. Read the
+  `CLAUDE.md`, treat it as the existing canonical doc, reconcile it exactly as Update mode does
+  (Step 6), and propose renaming it to `AGENTS.md` plus the `CLAUDE.md → AGENTS.md` symlink
+  (Step 7) — the vendor-neutral `AGENTS.md` becomes canonical, `CLAUDE.md` never stays the real
+  file.
 
 ## Step 2 — run the detector
 
 Run `${CLAUDE_SKILL_DIR}/scripts/detect.sh` via Bash from the repo root and parse its `KEY=value`
 output. It's read-only and best-effort per field — a missing tool or unmet precondition blanks
-only that field, not the rest. Treat `BRANCH_MODEL` specifically as an inferred guess, not a
-fact — its own output says so — and present it to the user as "detected, please confirm" rather
-than asserting it.
+only that field, not the rest. Two fields are inferred guesses, not facts — present them as
+"detected, please confirm" rather than asserting them:
+
+- **`BRANCH_MODEL`** — its own output says so.
+- **`SCOPES`** — derived from Conventional-Commit history, most-used first, so the low-count tail
+  is the prune candidate. Confirm the meaningful set and drop one-off/typo scopes (a `readme` or
+  `deploy` used once) before filling git.md's `<scopes>` placeholder.
 
 ## Step 3 — read the applicable rule files
 
@@ -110,8 +124,8 @@ by `<file from COMMIT_FORMAT_ENFORCEMENT>`; see it for the exact list) `` — ke
 
 For sections with no abstract source — what this repo is, its philosophy, structure &
 conventions, how to verify changes — emit skeleton headers with a one-line prompt each, seeded
-by light, cheap reads (root `README`, package manifests, top-level directory names already in
-`SCOPES`). Explicit `<!-- TODO: ... -->` markers, never invented narrative. This is deliberately
+by light, cheap reads (root `README`, package manifests, top-level directory names). Explicit
+`<!-- TODO: ... -->` markers, never invented narrative. This is deliberately
 narrower than `/init`'s full codebase analysis — point the user at `/init` if they want deeper
 codebase-derived drafting of these sections.
 
@@ -119,23 +133,50 @@ Include one `<!-- TODO: name a real exemplar file and a real anti-pattern file f
 line per notable convention you can identify a pattern for, but don't try to auto-select which
 files qualify — that's a judgment call prone to false positives, left to the human.
 
-## Step 6 — suggest-diff mode
+## Step 6 — Update mode (reconcile an existing doc)
 
-Read the existing `AGENTS.md`. For each mechanically-instantiated section (found by its lineage
-blockquote), recompute what Step 4 would produce today and diff it against what's there. Propose
-only that diff. Do not touch repo-domain sections.
+Read the existing canonical doc (the `AGENTS.md`, or the real `CLAUDE.md` in Migrate mode). Do
+three things, never overwriting hand-authored repo-domain prose:
+
+1. **Diff composed sections.** For each section carrying a lineage blockquote (Step 4), recompute
+   what Step 4 would produce today and propose only that diff — with one carve-out: the commit
+   `<scopes>` list is _augment-only_. A doc's curated scope list is human refinement, not drift;
+   propose _adding_ a scope that commit history shows but the list omits, and never propose
+   removing or re-widening a narrower curated set. (Without this, the history-ordered `SCOPES`
+   field would re-suggest every pruned scope on each run.)
+2. **Augment missing sections.** For each COMPOSE-derived section an applicable rule (Step 3)
+   would emit — for git.md + github.md: commit conventions, the Branch & PR model, local tooling,
+   credentials — that has _no_ corresponding section in the doc, propose _adding_ it, the same
+   output Draft mode would emit, inserted without disturbing what's already there. Judge coverage
+   per-section, not per-rule-file: a doc with a Commit-style section but no Branch & PR section is
+   _partially_ instantiated, and the absent section still gets offered. This is the path for a
+   hand-written `AGENTS.md` that predates the rules, or documents only part of one.
+3. **Surface contradictions, don't overwrite them.** If a hand-authored section contradicts a
+   rule you'd instantiate, do not silently replace it — under LOCAL-WINS the repo is _allowed_ to
+   override. Report it with that framing and offer the choice: **adopt** the rule's semantics
+   (replace the section with the instantiation), or **keep the override** — in which case propose
+   adding an override marker so the decision is recorded and never re-litigated:
+
+   `> Overrides **<rule>.md** § <topic> — reason: <why>. Deliberate; do not reconcile to the rule.`
+
+   A section already carrying that marker is a settled override: leave it, don't re-offer. The
+   marker is the sibling of Step 4's lineage line — one says "derived from a rule," the other
+   "deliberately departs from one" — and `audit-rules` reads the same marker to tell a deliberate
+   override from accidental drift.
 
 ## Step 7 — CLAUDE.md bridge
 
-If `HAS_CLAUDE_MD_SYMLINK` is empty and the repo doesn't already have one, propose (don't create)
-a gitignored `CLAUDE.md → AGENTS.md` symlink at the repo root, matching this repo's own pattern —
-mention it as a suggested follow-up step in the presented draft, not something written now.
+Unless `HAS_CLAUDE_MD` already starts with `symlink:`, propose (don't create) a gitignored
+`CLAUDE.md → AGENTS.md` symlink at the repo root, matching this repo's own pattern — mention it as
+a suggested follow-up step in the presented draft, not something written now. (In Migrate mode
+that means replacing the real `CLAUDE.md` with the symlink once it has become `AGENTS.md`.)
 
 ## Step 8 — present and wait
 
-Assemble the full draft (Draft mode) or diff (Suggest-diff mode) directly in this response.
-State plainly: "This is a proposal — nothing has been written to disk. Confirm and I'll
-create/update the file." Stop there.
+Assemble the full draft (Draft mode) or the reconciliation — diffs, augment additions, and
+contradiction choices (Update/Migrate mode) — directly in this response. State plainly: "This is
+a proposal — nothing has been written to disk. Confirm and I'll create/update the file." Stop
+there.
 
 ## Not in scope for v1
 

--- a/skills/compose-agents/SKILL.md
+++ b/skills/compose-agents/SKILL.md
@@ -77,6 +77,32 @@ Two traps, both real and both present in this repo's own `AGENTS.md`:
   model than git.md's default — you'll likely want to hand-write the Git workflow section, the
   way this pattern's own dotfiles repo does." Honesty about the gap beats a fabricated model.
 
+### Pointer-form for enforced specs
+
+AGENTS.md is the signpost, an enforcing config is the spec — don't let instantiation duplicate
+one into the other. This is "restate → point", not "enforced → delete": only the exact
+enumerable detail (a type list, a regex, a threshold) that a detected config already defines
+moves to pointer-form; the _why_ and the _workflow shape_ around it stay as prose regardless,
+since no config file can hold either.
+
+- When `COMMIT_FORMAT_ENFORCEMENT` is non-empty, instantiate git.md's Commits section's type
+  list as a pointer instead of enumerating it: `` `type` is a Conventional Commit type (enforced
+by `<file from COMMIT_FORMAT_ENFORCEMENT>`; see it for the exact list) `` — keep the rest of
+  that sentence (subject length, imperative mood, body wrap, `Co-authored-by`) as prose exactly
+  as git.md documents it, since nothing detected here confirms a config checks those specific
+  points too. When `COMMIT_FORMAT_ENFORCEMENT` is empty, fall back to the full literal type list
+  from git.md — there's nothing to point at, and per the "restate → point, not delete" rule an
+  unenforced repo still needs the spec written out somewhere.
+- Note whether the enforcement has a local mirror (`COMMIT_FORMAT_ENFORCEMENT`'s "local mirror"
+  vs "CI-only" suffix) in the pointer sentence — a CI-only gate is a slow, late loop, so say so
+  rather than implying a fast local check exists.
+- This same pointer-vs-restate judgment applies to any other COMPOSE-bearing content that
+  enumerates a config-defined value — the type list is the one concrete case detect.sh names
+  today, not the only one that could exist. Workflow _shape_ (step ordering, when to squash, when
+  to open a PR) is never a target for this — it stays prose even when a slow/CI-only gate
+  enforces it downstream, per git.md's own guidance, since no config teaches that shape ahead of
+  time.
+
 ## Step 5 — repo-domain TODO-skeleton (Draft mode)
 
 For sections with no abstract source — what this repo is, its philosophy, structure &

--- a/skills/compose-agents/scripts/detect.sh
+++ b/skills/compose-agents/scripts/detect.sh
@@ -69,16 +69,19 @@ if [[ -d .github/workflows ]]; then
   commit_format_file="$(grep -rlE '\(feat\|fix\|docs\|style\|refactor\|perf\|test\|build\|ci\|chore\)' .github/workflows/*.y*ml 2>/dev/null | head -1)"
 fi
 
-# Heuristic, not fact — flag as inferred to the caller. Looks for a workflow
-# that gates PRs on both a single-commit count and a Conventional Commit
-# subject, the signal this repo's own pr-guards.yml uses for its short-lived
-# -feature-branch + squash-per-PR + rebase-merge model. git.md's own
-# documented default is the long-lived-working-branch + squash-merge model;
-# absent this signal, assume that default rather than guessing further.
-branch_model="long-lived-working-branch+squash-merge (git.md default — no override signal found)"
+# Heuristic, not fact — flag as inferred to the caller. git.md documents
+# exactly one Branch & PR model (short-lived-feature-branch + rebase-merge;
+# #128 consolidated it off the older long-lived-working-branch + squash-merge
+# default). This looks for the CI signal this repo's own pr-guards.yml uses
+# to enforce it — a workflow gating PRs on both a single-commit count and a
+# Conventional Commit subject. Presence confirms enforcement is actually
+# wired up; absence doesn't mean a different model — git.md has no other
+# model to fall back to — it just means compose-agents can't confirm
+# enforcement from CI alone.
+branch_model="short-lived-feature-branch+squash-per-PR+rebase-merge (git.md's only documented model — no CI signal found to confirm enforcement)"
 if [[ -n "$commit_format_file" ]] &&
   grep -rlqE 'pull_request\.commits' .github/workflows/*.y*ml 2>/dev/null; then
-  branch_model="short-lived-feature-branch+squash-per-PR+rebase-merge (HEURISTIC — verify against the repo's actual docs)"
+  branch_model="short-lived-feature-branch+squash-per-PR+rebase-merge (confirmed by pr-guards-style CI signal)"
 fi
 echo "BRANCH_MODEL=$branch_model"
 

--- a/skills/compose-agents/scripts/detect.sh
+++ b/skills/compose-agents/scripts/detect.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Best-effort repo-fact detection for the compose-agents skill. Run from the
+# target repo's root. Emits KEY=value lines, one per field, always emitting
+# the key even when the value is empty so the caller can tell "detected
+# empty" from "field never ran". Read-only — never mutates repo or git
+# state, safe to run repeatedly against any repo, including someone else's.
+#
+# Each field is independently guarded: a missing tool (e.g. no `gh`) or an
+# unmet precondition only blanks that one field, never the rest — mirrors
+# this repo's own required()/optional() split in macos/deploy.zsh and
+# linux/deploy.sh.
+set -uo pipefail
+
+is_git_repo=false
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  is_git_repo=true
+fi
+echo "IS_GIT_REPO=$is_git_repo"
+
+remote_host=""
+if $is_git_repo; then
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  case "$origin_url" in
+    *github.com*) remote_host="github.com" ;;
+    *gitlab.com*) remote_host="gitlab.com" ;;
+    *bitbucket.org*) remote_host="bitbucket.org" ;;
+    "") remote_host="" ;;
+    *) remote_host="other" ;;
+  esac
+fi
+echo "REMOTE_HOST=$remote_host"
+
+is_go_repo=false
+if [[ -f go.mod ]] || find . -maxdepth 3 -name '*.go' -print -quit 2>/dev/null | grep -q .; then
+  is_go_repo=true
+fi
+echo "IS_GO_REPO=$is_go_repo"
+
+scopes=""
+if $is_git_repo; then
+  scopes="$(find . -maxdepth 1 -mindepth 1 -type d -not -path '*/.*' -exec basename {} \; |
+    sort | paste -sd, -)"
+fi
+echo "SCOPES=$scopes"
+
+version_scheme=""
+if [[ -f cliff.toml ]]; then
+  version_scheme="SemVer (git-cliff)"
+elif $is_git_repo && git tag -l 2>/dev/null | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  version_scheme="SemVer (git tags, no git-cliff detected)"
+fi
+echo "VERSION_SCHEME=$version_scheme"
+
+release_automation=""
+if [[ -d .github/workflows ]]; then
+  release_automation="$(find .github/workflows -maxdepth 1 -iname '*release*' -exec basename {} \; |
+    sort | paste -sd, -)"
+fi
+echo "RELEASE_AUTOMATION=$release_automation"
+
+# Heuristic, not fact — flag as inferred to the caller. Looks for a workflow
+# that gates PRs on both a single-commit count and a Conventional Commit
+# subject, the signal this repo's own pr-guards.yml uses for its short-lived
+# -feature-branch + squash-per-PR + rebase-merge model. git.md's own
+# documented default is the long-lived-working-branch + squash-merge model;
+# absent this signal, assume that default rather than guessing further.
+branch_model="long-lived-working-branch+squash-merge (git.md default — no override signal found)"
+if [[ -d .github/workflows ]] &&
+  grep -rlqE 'pull_request\.commits' .github/workflows/*.y*ml 2>/dev/null &&
+  grep -rlqE '\(feat\|fix\|docs\|style\|refactor\|perf\|test\|build\|ci\|chore\)' .github/workflows/*.y*ml 2>/dev/null; then
+  branch_model="short-lived-feature-branch+squash-per-PR+rebase-merge (HEURISTIC — verify against the repo's actual docs)"
+fi
+echo "BRANCH_MODEL=$branch_model"
+
+protected_branch=""
+if $is_git_repo; then
+  protected_branch="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+  if [[ -z "$protected_branch" ]]; then
+    for candidate in main master; do
+      if git show-ref --verify --quiet "refs/remotes/origin/$candidate" ||
+        git show-ref --verify --quiet "refs/heads/$candidate"; then
+        protected_branch="$candidate"
+        break
+      fi
+    done
+  fi
+fi
+echo "PROTECTED_BRANCH=$protected_branch"
+
+pre_commit_tool=""
+if [[ -f lefthook.yml ]] || [[ -f lefthook.yaml ]]; then
+  pre_commit_tool="lefthook"
+elif [[ -f .pre-commit-config.yaml ]]; then
+  pre_commit_tool="pre-commit (python)"
+elif [[ -d .husky ]]; then
+  pre_commit_tool="husky"
+fi
+echo "PRE_COMMIT_TOOL=$pre_commit_tool"
+
+credential_pattern=""
+if [[ -f .envrc.local.example ]] && grep -qE '(GH_TOKEN|_TOKEN|_KEY|_SECRET)' .envrc.local.example 2>/dev/null; then
+  credential_pattern="direnv-scoped token (see .envrc.local.example)"
+fi
+echo "CREDENTIAL_PATTERN=$credential_pattern"
+
+gh_available=false
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh_available=true
+fi
+echo "GH_AVAILABLE=$gh_available"
+
+has_agents_md=""
+[[ -f AGENTS.md ]] && has_agents_md="AGENTS.md"
+echo "HAS_AGENTS_MD=$has_agents_md"
+
+has_claude_md_symlink=""
+if [[ -L CLAUDE.md ]]; then
+  has_claude_md_symlink="$(readlink CLAUDE.md)"
+fi
+echo "HAS_CLAUDE_MD_SYMLINK=$has_claude_md_symlink"

--- a/skills/compose-agents/scripts/detect.sh
+++ b/skills/compose-agents/scripts/detect.sh
@@ -58,6 +58,17 @@ if [[ -d .github/workflows ]]; then
 fi
 echo "RELEASE_AUTOMATION=$release_automation"
 
+# Looks for a workflow file whose regex enforces a Conventional Commit
+# subject — reused below for two different purposes: BRANCH_MODEL's
+# heuristic (paired with a single-commit-count check) and
+# COMMIT_FORMAT_ENFORCEMENT (named on its own, regardless of branch model),
+# so compose-agents can point at the actual enforcing file instead of
+# restating the type list it defines.
+commit_format_file=""
+if [[ -d .github/workflows ]]; then
+  commit_format_file="$(grep -rlE '\(feat\|fix\|docs\|style\|refactor\|perf\|test\|build\|ci\|chore\)' .github/workflows/*.y*ml 2>/dev/null | head -1)"
+fi
+
 # Heuristic, not fact — flag as inferred to the caller. Looks for a workflow
 # that gates PRs on both a single-commit count and a Conventional Commit
 # subject, the signal this repo's own pr-guards.yml uses for its short-lived
@@ -65,12 +76,26 @@ echo "RELEASE_AUTOMATION=$release_automation"
 # documented default is the long-lived-working-branch + squash-merge model;
 # absent this signal, assume that default rather than guessing further.
 branch_model="long-lived-working-branch+squash-merge (git.md default — no override signal found)"
-if [[ -d .github/workflows ]] &&
-  grep -rlqE 'pull_request\.commits' .github/workflows/*.y*ml 2>/dev/null &&
-  grep -rlqE '\(feat\|fix\|docs\|style\|refactor\|perf\|test\|build\|ci\|chore\)' .github/workflows/*.y*ml 2>/dev/null; then
+if [[ -n "$commit_format_file" ]] &&
+  grep -rlqE 'pull_request\.commits' .github/workflows/*.y*ml 2>/dev/null; then
   branch_model="short-lived-feature-branch+squash-per-PR+rebase-merge (HEURISTIC — verify against the repo's actual docs)"
 fi
 echo "BRANCH_MODEL=$branch_model"
+
+# Whether a Conventional-Commit type list is mechanically enforced anywhere
+# in this repo, and whether that enforcement has a fast local mirror (a
+# commit-msg hook) or is CI-only (the agent may not reach it mid-session).
+# Empty means no enforcement was found — compose-agents falls back to
+# restating the type list in full, since there's nothing to point at.
+commit_format_enforcement=""
+if [[ -n "$commit_format_file" ]]; then
+  if grep -rlqE 'commit-msg' lefthook.y*ml .husky/commit-msg .commitlintrc* 2>/dev/null; then
+    commit_format_enforcement="$commit_format_file (has a local pre-commit mirror)"
+  else
+    commit_format_enforcement="$commit_format_file (CI-only, no local mirror found)"
+  fi
+fi
+echo "COMMIT_FORMAT_ENFORCEMENT=$commit_format_enforcement"
 
 protected_branch=""
 if $is_git_repo; then

--- a/skills/compose-agents/scripts/detect.sh
+++ b/skills/compose-agents/scripts/detect.sh
@@ -36,10 +36,24 @@ if [[ -f go.mod ]] || find . -maxdepth 3 -name '*.go' -print -quit 2>/dev/null |
 fi
 echo "IS_GO_REPO=$is_go_repo"
 
+# Commit scopes come from commit history, not the filesystem: the type(scope):
+# subjects a repo actually uses are its real scope vocabulary. A top-level dir
+# list both over-counts (dirs that never receive scoped commits) and
+# under-counts (a scope like `release` or `ci` that maps to no dir). Emit them
+# most-used first, so the low-count tail reads as the prune candidate for
+# compose-agents' confirm step. Fall back to top-level dirs only when there's
+# no Conventional-Commit history to learn from (a fresh repo) — a coarse guess
+# beats an empty field.
 scopes=""
 if $is_git_repo; then
-  scopes="$(find . -maxdepth 1 -mindepth 1 -type d -not -path '*/.*' -exec basename {} \; |
-    sort | paste -sd, -)"
+  scopes="$(git log --format=%s 2>/dev/null |
+    grep -oE '^[a-z]+\([a-z0-9._-]+\)!?:' |
+    sed -E 's/^[a-z]+\(([^)]+)\)!?:.*/\1/' |
+    sort | uniq -c | sort -rn | awk '{print $2}' | paste -sd, -)"
+  if [[ -z "$scopes" ]]; then
+    scopes="$(find . -maxdepth 1 -mindepth 1 -type d -not -path '*/.*' -exec basename {} \; |
+      sort | paste -sd, -)"
+  fi
 fi
 echo "SCOPES=$scopes"
 
@@ -141,8 +155,15 @@ has_agents_md=""
 [[ -f AGENTS.md ]] && has_agents_md="AGENTS.md"
 echo "HAS_AGENTS_MD=$has_agents_md"
 
-has_claude_md_symlink=""
+# Distinguish the three CLAUDE.md states the compose modes turn on: absent
+# (Draft), a symlink to AGENTS.md (Update — the expected companion), or a real
+# file with no AGENTS.md (Migrate — a legacy/non-Claude layout to move onto
+# AGENTS.md). A bare `-L` test can't tell a real file from absent, which would
+# collapse Migrate into Draft.
+has_claude_md=""
 if [[ -L CLAUDE.md ]]; then
-  has_claude_md_symlink="$(readlink CLAUDE.md)"
+  has_claude_md="symlink:$(readlink CLAUDE.md)"
+elif [[ -f CLAUDE.md ]]; then
+  has_claude_md="file"
 fi
-echo "HAS_CLAUDE_MD_SYMLINK=$has_claude_md_symlink"
+echo "HAS_CLAUDE_MD=$has_claude_md"

--- a/skills/grilling/SKILL.md
+++ b/skills/grilling/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: grilling
+description: >-
+  Extracts decisions one at a time before committing to a plan, instead of guessing a batch of
+  assumptions. Looks up anything discoverable in the environment itself rather than asking; puts
+  each real decision to the human as a single question with a recommended answer, and doesn't act
+  until it's confirmed. Use when scope, structure, or approach is genuinely undecided and guessing
+  would waste a round — shaping a new epic, splitting an overgrown issue, defining a spike's
+  question and deliverable, weighing a spike's verdict, or pre-gating an issue with thin
+  acceptance criteria. Not for routine, already-clear work.
+---
+
+# Grilling
+
+A protocol for extracting decisions, not a form to fill out. The failure mode this replaces:
+guessing a batch of assumptions up front and burning a round when one is wrong.
+
+## Rules
+
+1. **Look it up before you ask.** Anything discoverable from the environment — an existing file,
+   a label taxonomy, a past decision in memory, prior art in the repo — isn't a question. Read it.
+2. **One question at a time.** Ask, wait, incorporate the answer, ask the next. Never a numbered
+   batch of unrelated questions in one message — each answer can change what's worth asking next.
+3. **Every question carries a recommendation.** State the decision, your recommended answer, and
+   why in one or two sentences. The human is confirming or redirecting a specific call, not
+   opening a blank design discussion.
+4. **Don't act until confirmed.** No drafting the epic body, splitting the issue, or writing the
+   plan ahead of the answer — grilling ends when the open decisions run out, not when you get
+   tired of asking.
+
+## When to stop
+
+Once every genuinely open decision has an answer, the interview is done — hand off to whatever
+comes next (drafting the epic, writing the split, defining the spike). Don't manufacture more
+questions once nothing is actually undecided.

--- a/skills/groom-backlog/SKILL.md
+++ b/skills/groom-backlog/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: groom-backlog
+description: >-
+  Runs a periodic backlog sweep: find untriaged issues, re-weigh priorities, dedupe, tighten weak
+  issues, catch labels that have drifted from the repo's own conventions, verify epic children
+  still exist, propose epic rollups, and surface what's ready versus blocked. Use when asked to
+  groom, sweep, or do backlog maintenance on a GitHub issue tracker. Repo-agnostic — reads the
+  repo's own label taxonomy and conventions at runtime; repo-specific checks live in that repo's
+  own notes, read as the last step.
+---
+
+# Groom Backlog
+
+The periodic pass that keeps a backlog trustworthy. Leave it smaller and sharper than you found
+it.
+
+## Sweep
+
+1. **Find untriaged issues from live state.** An open issue with no `priority:` label (or this
+   repo's equivalent) hasn't been triaged — the absence is the marker. Classify it (type +
+   priority).
+2. **Re-weigh priorities.** A stale priority is worse than none — weigh impact against effort
+   against current facts, not the label as it was set.
+3. **Dedupe.** Search before filing; fold true duplicates into the older or more complete issue,
+   confirming it's still open first.
+4. **Tighten weak issues.** Vague titles, missing acceptance criteria, no reproduction steps —
+   sharpen in place or mark what's missing.
+5. **Check labels against the repo's own conventions.** A label scheme drifts — a `status:` value
+   that's stopped being used, a `theme:` that's grown too broad, a convention stated in
+   AGENTS.md/README that issues no longer follow.
+6. **Verify epic children still exist.** A referenced child issue returning 404/410 isn't closed —
+   it was deleted or renumbered. Repoint the epic, don't leave a dead reference.
+7. **Propose epic rollups.** When 3+ open standalone issues share one concrete deliverable — not
+   just a common theme label — propose consolidating them under a new or existing epic.
+8. **Surface ready versus blocked.** A short list: what's actually next to act on, and what's
+   blocked and why.
+9. **Read the repo's sweep notes.** Repo-specific checks — a known dupe-folding pattern, a label
+   quirk unique to this backlog — live in that repo's own memory or docs, not here. Read them last
+   and apply them alongside the generic sweep above.
+
+## Non-goals
+
+Bulk relabeling, closing many issues, or restructuring milestones wholesale still needs a human
+nod first — this skill proposes, it doesn't execute destructive moves unsupervised.

--- a/skills/implement-issue/SKILL.md
+++ b/skills/implement-issue/SKILL.md
@@ -29,11 +29,16 @@ opening PRs live in the repo's own git workflow doc — this skill doesn't resta
    AGENTS.md (or CONTRIBUTING, or an equivalent stated doc) for the repo's concrete commands and
    conventions; absent one, fall back to the generic short-lived-branch-plus-protected-main model.
    Zero mechanics restated here — this step is a pointer, not a protocol.
-4. **Tie the PR to the issue.** PR body carries `Closes #<N>`. Journal _deviations from the
+4. **Author as the implementor.** Every `git commit` in this ritual (including the squash) runs
+   with `GIT_AUTHOR_NAME=carpet-stain-implementor` and
+   `GIT_AUTHOR_EMAIL=316583991+carpet-stain-implementor@users.noreply.github.com` — honest blame
+   (ADR-0038 in the dotfiles repo). Author only: committer, push, and merge stay the human's;
+   never add an AI co-author trailer.
+5. **Tie the PR to the issue.** PR body carries `Closes #<N>`. Journal _deviations from the
    issue's plan_ specifically as PR comments while working — that's the signal a plan-vs-diff
    check reads later.
-5. **Write terse.** Code comments explain why, not what; detail belongs on the issue, not in the
+6. **Write terse.** Code comments explain why, not what; detail belongs on the issue, not in the
    diff. The PR description and comments stay terse by the same discipline.
-6. **At finalize, hand off.** Apply the repo's PR handoff rule if it states one (self-sufficient
+7. **At finalize, hand off.** Apply the repo's PR handoff rule if it states one (self-sufficient
    top post, journal as optional depth) — rewrite the PR body to stand alone before flipping ready.
    Stop there. Flipping the PR to ready-for-review is the handoff; merging is someone else's call.

--- a/skills/implement-issue/SKILL.md
+++ b/skills/implement-issue/SKILL.md
@@ -32,7 +32,7 @@ opening PRs live in the repo's own git workflow doc — this skill doesn't resta
 4. **Author as the implementor.** Every `git commit` in this ritual (including the squash) runs
    with `GIT_AUTHOR_NAME=carpet-stain-implementor` and
    `GIT_AUTHOR_EMAIL=316583991+carpet-stain-implementor@users.noreply.github.com` — honest blame
-   (ADR-0038 in the dotfiles repo). Author only: committer, push, and merge stay the human's;
+   (carpet-stain/dotfiles ADR-0038). Author only: committer, push, and merge stay the human's;
    never add an AI co-author trailer.
 5. **Tie the PR to the issue.** PR body carries `Closes #<N>`. Journal _deviations from the
    issue's plan_ specifically as PR comments while working — that's the signal a plan-vs-diff

--- a/skills/implement-issue/SKILL.md
+++ b/skills/implement-issue/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: implement-issue
+description: >-
+  Worker-session ritual for implementing a single shaped GitHub issue end to end: verify it's
+  ready, branch and open a draft PR, implement exactly what the issue's top post specifies,
+  journal deviations from the plan, write terse, and hand off a ready-for-review PR whose body
+  stands alone. Use when asked to implement, build, or work a specific issue number in a fresh
+  session with no other context. Points at the repo's own git workflow for all branch/PR
+  mechanics — doesn't restate them.
+---
+
+# Implement Issue
+
+A thin wrapper around "go implement the spec." The mechanics of branching, committing, and
+opening PRs live in the repo's own git workflow doc — this skill doesn't restate them.
+
+## Steps
+
+1. **Resolve the issue.** `gh issue view <N>`. Confirm it's OPEN — a closed issue is a shipped
+   record, not something to reopen and build on. If the repo runs a plan-review gate (look for
+   `needs-plan-review`/`plan-approved` labels or a stated convention in AGENTS.md), confirm it's
+   `plan-approved` before starting; if the gate exists and the issue isn't approved yet, stop and
+   say so instead of improvising a plan.
+2. **The top post is the spec.** Implement what's written there — not an improvisation on it, not
+   a redesign. If something in the spec turns out to be wrong or impossible, say so and stop
+   rather than silently deviating.
+3. **Follow the repo's own git workflow for mechanics.** Branch, open the PR in draft as soon as
+   the first commit exists, commit freely, squash to one commit when ready, finalize. Read
+   AGENTS.md (or CONTRIBUTING, or an equivalent stated doc) for the repo's concrete commands and
+   conventions; absent one, fall back to the generic short-lived-branch-plus-protected-main model.
+   Zero mechanics restated here — this step is a pointer, not a protocol.
+4. **Tie the PR to the issue.** PR body carries `Closes #<N>`. Journal _deviations from the
+   issue's plan_ specifically as PR comments while working — that's the signal a plan-vs-diff
+   check reads later.
+5. **Write terse.** Code comments explain why, not what; detail belongs on the issue, not in the
+   diff. The PR description and comments stay terse by the same discipline.
+6. **At finalize, hand off.** Apply the repo's PR handoff rule if it states one (self-sufficient
+   top post, journal as optional depth) — rewrite the PR body to stand alone before flipping ready.
+   Stop there. Flipping the PR to ready-for-review is the handoff; merging is someone else's call.


### PR DESCRIPTION
## What

Phase 1 of carpet-stain/dotfiles#567: moves the stable, low-churn subset of dotfiles'
`claude/` agent-config tree here — `rules/{universal,domain,tools,platform}` (minus
`voice.md`), `agents/plan-reviewer.md`, and six skills (`audit-memory`, `audit-rules`,
`compose-agents`, `grilling`, `groom-backlog`, `implement-issue`).

## History

Extracted with `git filter-repo --path <each kept path> --path-rename claude/:` against a
fresh dotfiles clone (50 commits touching only the kept paths, `claude/` prefix stripped),
then `git rebase --onto main --root` to replay that history linearly on top of this repo's
current `main` — no merge commit, fully linear, `git blame`/`git log` intact for every moved
file. One more commit on top inverts each file's "Canonical source: my dotfiles" header,
scrubs dotfiles-specific worked examples baked into `audit-rules`/`audit-memory` (a `#106`
contradiction example, line-count-before/after anecdotes, "this repo's own pr-guards.yml"),
and fully-qualifies every surviving real `#NNN`/ADR pointer as `carpet-stain/dotfiles#NNN` /
`carpet-stain/dotfiles ADR-NNNN` so it resolves cross-repo instead of dangling.

## Merge mechanics — reads odd, is deliberate

This repo's `protect main` ruleset requires every PR to be exactly 1 commit
(`pr-guards.yml`'s `single commit` check) before merge. That's structurally incompatible with
carrying 51 real historical commits — squashing would destroy the exact history this PR
exists to preserve. Per agents#3's own contingency note ("a temporary infra ruleset
enforcement toggle, admin-tier, infra — never a forced push"), I'm temporarily dropping
`single commit` and `conventional commit` from `protect main`'s required status checks for
this one merge (via the gh-admin-token path), merging via the repo's normal `rebase` method
(preserves every commit's SHA-changing but content/author/date verbatim, no squash), then
restoring the ruleset to its exact original JSON immediately after. `adr guard` stays on
throughout — it only fires on `architecture`-labeled PRs, and this one isn't labeled that way,
so it passes without needing a relaxation.

Deviation from carpet-stain/dotfiles#567 as written: the issue's Dependencies section expected
agents#3's governance base to "layer on top of this issue's git filter-repo history import as
fresh commits" — i.e. history-import first, governance second. In practice agents#3 landed
first (closed today), so this PR merges the filtered history *into* the existing governance
base instead, via `git rebase --onto main --root` rather than the other direction. Same end
state (governance base + full history, both present on `main`), reverse arrival order.

## Not in this PR

`voice.md` and `backlog-manager.md` stay in dotfiles (Phase 2, dotfiles#569) — see dotfiles#567
for the full scope rationale. The `README.md` here is expanded with the "how the rules
tree/skills/authoring conventions work" content from dotfiles' `claude/README.md` — first
draft, happy to iterate.

No-Issue: this repo's issue tracker doesn't have a #567 — the driving issue lives in
carpet-stain/dotfiles.