### PR TITLE
feat(claude): record token cost at finalize if the repo tracks it

### DIFF
--- a/skills/implement-issue/SKILL.md
+++ b/skills/implement-issue/SKILL.md
@@ -39,6 +39,9 @@ opening PRs live in the repo's own git workflow doc — this skill doesn't resta
    check reads later.
 6. **Write terse.** Code comments explain why, not what; detail belongs on the issue, not in the
    diff. The PR description and comments stay terse by the same discipline.
-7. **At finalize, hand off.** Apply the repo's PR handoff rule if it states one (self-sufficient
+7. **Record token cost, if this repo tracks it.** Check AGENTS.md for a per-issue token-accounting
+   step (a `just`/script recipe keyed by the issue number) and run it before finalizing. Purely
+   repo-specific — skip silently where none is defined.
+8. **At finalize, hand off.** Apply the repo's PR handoff rule if it states one (self-sufficient
    top post, journal as optional depth) — rewrite the PR body to stand alone before flipping ready.
    Stop there. Flipping the PR to ready-for-review is the handoff; merging is someone else's call.


### PR DESCRIPTION
<!-- Title = the Conventional Commit this squashes to: type(scope): imperative subject -->

## Summary

carpet-stain/dotfiles#476 added a per-issue token-accounting step
(`just token-cost <N>`, run manually), but nothing in this skill's own
finalize sequence reminded a session to run it before a PR goes ready — an
issue could close with no cost comment unless someone remembered by hand.
Adds a step between "write terse" and "hand off": check the repo's AGENTS.md
for a recorded per-issue accounting recipe and run it before flipping the PR
ready. Repo-agnostic — points at AGENTS.md rather than hardcoding
dotfiles' `just token-cost`, since this skill runs across repos that may not
define one at all.

## Decision journal

- No issue exists in this repo for the change — it came directly out of a
  dotfiles conversation walking through the #533 token-observability epic's
  four children (#516/#517/#518/#476) once all four had merged. Opening this
  PR directly rather than filing-then-implementing, since the change is a
  single small, already-scoped step addition.
- Placed as step 7, before the existing "at finalize, hand off" step
  (renumbered to 8) — token spend for an issue is essentially settled by the
  time a session is ready to flip a PR to ready-for-review, so this is the
  natural last point to capture it before handoff.
- Kept the wording silent-skip when a repo doesn't define an accounting step
  (most repos won't) — this must not become a hard requirement or break the
  skill for every other repo it runs against.

## Verification

- `just lint` — clean.
- Read through the full skill file end-to-end after the edit to confirm the
  renumbered step 8 still reads correctly and the new step 7 doesn't
  contradict step 3's existing "repo-specific git mechanics" framing.

## Doc-ownership checklist

- [x] Behavior or a convention changed → the docs that own it are updated in this PR. — The skill file itself is the doc; no other doc restates its steps.
- [x] Docs point at the enforcing config/rule, not restate it. — Points at "AGENTS.md" and "a `just`/script recipe", not a hardcoded dotfiles command.
- [x] Architecturally significant or hard-to-reverse decision → an ADR under `docs/adr/`, and this PR labeled `architecture`. — Not architecturally significant; a one-step addition to an existing skill.
- [x] Reverses a recorded decision → the old ADR is marked `superseded by NNNN`, not edited to match. — N/A

No-Issue: follows up on carpet-stain/dotfiles#476 (already closed there via dotfiles#611); no issue tracked in this repo.