### PR TITLE
docs(rules): defer gh elevation mechanics to the repo credential doc

### DIFF
--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -29,10 +29,10 @@ checks. "PR" is GitHub's review/merge request.
 
 `gh` defaults to a scoped-down fine-grained PAT (contents/PRs/actions read-write, no
 Administration), not a full `gh auth login` session, so routine work can't touch repo settings or
-branch protection — elevate explicitly (`env -u GH_TOKEN -u GITHUB_TOKEN gh ...` — both vars, since
-a repo aliasing `GITHUB_TOKEN` to the same scoped token means dropping `GH_TOKEN` alone is a no-op)
-only for the one action that needs admin. `act` runs the Actions workflows locally via Docker, for
-testing without pushing.
+branch protection. How to elevate is credential-setup-specific — the repo's own credential doc
+(AGENTS.md or equivalent, authoritative under LOCAL-WINS) names the mechanic; elevate only for
+the one action that needs admin, never as the session default. `act` runs the Actions workflows
+locally via Docker, for testing without pushing.
 
 ## Early draft PRs — `git pr` / `git pr --draft`
 


### PR DESCRIPTION
Rewords `rules/platform/github.md` § Local tooling: the elevation sentence hardcoded `env -u GH_TOKEN -u GITHUB_TOKEN gh ...`, which stopped being true on 2026-08-09 — the keyring now holds the dev PAT (infra#151), so the env-drop yields the scoped token, and admin ops ride infra's Keychain-gated SSM wrapper (infra ADR-0013). The baseline now defers to the repo's own credential doc (authoritative under LOCAL-WINS) instead of naming a mechanic that rots.

Verification: `just lint` green.

Closes carpet-stain/dotfiles#529