### PR TITLE
docs(claude): defer gh credentials to repo docs

### DIFF
--- a/rules/platform/github.md
+++ b/rules/platform/github.md
@@ -27,12 +27,15 @@ checks. "PR" is GitHub's review/merge request.
 
 ## Local tooling
 
-`gh` defaults to a scoped-down fine-grained PAT (contents/PRs/actions read-write, no
-Administration), not a full `gh auth login` session, so routine work can't touch repo settings or
-branch protection. How to elevate is credential-setup-specific — the repo's own credential doc
-(AGENTS.md or equivalent, authoritative under LOCAL-WINS) names the mechanic; elevate only for
-the one action that needs admin, never as the session default. `act` runs the Actions workflows
-locally via Docker, for testing without pushing.
+Routine `gh` work runs under a scoped-down credential resolved by the repo's own environment
+(its `.envrc` or equivalent), never a full-admin session, so an agent driving the CLI can't touch
+repo settings or branch protection. Which credential that is, what scopes it carries, and how to
+elevate for the one action that needs admin are the repo's own credential doc's to state
+(AGENTS.md — LOCAL-WINS): those mechanics vary per repo and drift, so this file keeps only the
+principle. One portable rule when elevation works by dropping env vars: drop every variable that
+could carry the same token — a repo often aliases `GITHUB_TOKEN` to the same scoped value as
+`GH_TOKEN`, so dropping one alone is a no-op. `act` runs the Actions workflows locally via Docker,
+for testing without pushing.
 
 ## Early draft PRs — `git pr` / `git pr --draft`
 


### PR DESCRIPTION
Rewords `rules/platform/github.md` § Local tooling to stop naming a concrete credential mechanic — the fine-grained PAT, its (stale, pre-Issues) scope list, and `env -u GH_TOKEN -u GITHUB_TOKEN` as *the* elevation path. Those are per-repo facts that drift; the routine-credential and elevation mechanics now defer to each repo's own credential doc (AGENTS.md, LOCAL-WINS), and this file keeps only the principles: routine work runs under a scoped-down credential resolved by the repo's environment, elevation is explicit and per-action, and env-var elevation must drop every var that could carry the same token (the alias no-op caveat — the one portable mechanic kept).

Verified: `just lint` green.

Closes carpet-stain/dotfiles#529