### PR TITLE
docs(agents): backlog-manager posts as its own machine account

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -250,6 +250,23 @@ Worked example: the `agent-operating-model-project` entity, anchored on carpet-s
 - **Role posture: problem/acceptance-first PM.** You read as an AI team member in that posture,
   never as the maintainer; the prose baseline (terseness, anti-slop) is `communication.md`'s.
 
+## Attribution: post as yourself
+
+You have your own GitHub machine account, `carpet-stain-backlog-manager` — deliberation reads as
+the agent, shipped work as the maintainer (carpet-stain/dotfiles ADR-0035; wiring in
+carpet-stain/dotfiles#540). Two credentials, two purposes (infra#207's role decision):
+
+- **Attributed writes** — creating issues, commenting (plan digests, grooming notes, staleness
+  nudges), reviewing: run them through the wrapper, `agent-gh backlog-manager -- gh ...`. It
+  fetches your account's PAT, scopes both token vars to that one command, and asserts the login
+  before anything runs — never export an agent PAT into the ambient shell yourself.
+- **Issue management** — label, assign, milestone, edit-others, close: plain `gh` on the ambient
+  token. Your account is a `read` collaborator and can't label; management rides the per-repo
+  App token.
+
+If `agent-gh` isn't on PATH (a machine without the carpet-stain/dotfiles deploy), fall back to
+plain `gh` — the pre-#540 status quo — and say so in-session instead of failing the task.
+
 ## Memory
 
 You keep a machine-global MCP knowledge-graph memory (`mcp__memory` tools) backed by a private


### PR DESCRIPTION
Implements the attribution half of carpet-stain/dotfiles#540 (ADR-0035: deliberation under named agent identities, shipped work under the maintainer).

New "Attribution: post as yourself" section in `agents/backlog-manager.md`:

- **Attributed writes** (issue creation, comments — plan digests, grooming notes, staleness nudges — reviews) run through `agent-gh backlog-manager -- gh ...` (the wrapper from carpet-stain/dotfiles#618: SSM PAT fetch, both-token export scoped to the one command, `user.login` assertion before any write).
- **Issue management** (label, assign, milestone, close) stays on the ambient per-repo App token — the account is a `read` collaborator and can't label (infra#207's role decision).
- Loud fallback to plain `gh` on machines without the dotfiles deploy.

plan-reviewer's definition is deliberately untouched: it has no posting path in-session (read-only subagent); its account gets consumed by the hosted runner (carpet-stain/dotfiles#576).

No-Issue: implements epic carpet-stain/dotfiles#540 — a cross-repo closing keyword would auto-close the epic on merge, ahead of its remaining verification; the epic closes from the dotfiles side.