### PR TITLE
feat(scripts): renderer for the vendored agent cloud channel

### DIFF
--- a/docs/adr/0002-vendored-agent-cloud-channel.md
+++ b/docs/adr/0002-vendored-agent-cloud-channel.md
@@ -1,0 +1,110 @@
+# 2. Vendored agent cloud channel
+
+Date: 2026-08-17
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0039 (`carpet-stain/dotfiles`) distributes agent definitions as a git submodule symlinked
+into `~/.claude/` — a single-workstation, local-CLI channel. `carpet-stain/dotfiles#582`
+(Decision 1) requires `backlog-manager` to also work from claude.ai/code web and iOS. Verified
+surface fact (Claude Code docs, 2026-08-16): a cloud session loads only **repo-level
+`.claude/agents/`** — `~/.claude/agents/` never loads there. So on cloud surfaces an agent has no
+definition to load; ADR-0039's channel doesn't reach them.
+
+## Decision
+
+A second, **additive** project-level channel, pull-based and consumer-owned:
+
+- **Pull, not push.** Each consumer repo runs a scheduled + `workflow_dispatch` GitHub Actions
+  workflow that checks out this (public) repo, runs `scripts/render-agent.sh`, and opens a drift
+  PR using its own `GITHUB_TOKEN` — no cross-repo write credential, no producer-side consumer
+  registry.
+- **Vendored real files, not a submodule-in-repo.** Cloud reads plain files at
+  `.claude/agents/<name>.md`; a gitlink may not init or be readable there.
+- **Scope = named-skill closure**, not the whole tree: a vendored agent's persona plus the skills
+  it instructs the _in-role_ agent to **run** (a real, walkable edge — e.g. `backlog-manager.md` →
+  `grilling`, `groom-backlog`). Skills named only as backstops that a separate fresh-context
+  subagent runs (e.g. `audit-memory`, `audit-rules`) are excluded — they never execute in the
+  rendered session. **Rules are out of scope for v1**: ADR-0008 loads rules by directory presence,
+  not an agent→rule edge, so a "rules closure" would reintroduce the per-repo whitelist that ADR
+  already rejected. Whether a repo-committed rules dir loads on cloud at all, and how, is an open
+  question — tracked as a separate spike, gating any future rules vendoring.
+- **A cloud-channel transform, not a pure copy.** `mcpServers:` frontmatter (and its explanatory
+  comment) is stripped, `mcp__memory` is dropped from `tools:`, and a persona's `## Memory` section
+  is replaced with an explicit "memory unavailable on this surface" note. A def that still _calls_
+  a tool it no longer has is a worse failure than one that never claimed the capability.
+- **Owned carve-out only.** The renderer writes and `--check`s exactly `.claude/agents/<name>.md`,
+  `.claude/skills/<name>/`, and `.claude/.agents-ref` — never a whole-`.claude/` diff.
+  `settings.json` and consumer-local skills (e.g. dotfiles' `verify-nvim-config`, ADR-0039: STAYS
+  local) are outside the carve-out by construction.
+- **A consumer-pinned drift guard**, not a floating-`main` one: CI runs the renderer in `--check`
+  mode against the SHA recorded in the consumer's own `.claude/.agents-ref` — never this repo's
+  current `main`. Upstream churn can't redden an unrelated consumer PR; it surfaces only as the
+  next scheduled drift PR bumping the pin. **This resolves ADR-0039's SHA-pinning
+  deferral (`carpet-stain/dotfiles` ADR-0039) for the cloud channel only** — 0039's deferral still
+  stands, unchanged, for the local/submodule channel. The guard no-ops when `.agents-ref` is
+  absent (a virgin consumer has nothing vendored yet to check); the first sync PR writes the ref
+  and the carve-out atomically, so the two never exist half-populated.
+- **v1 ships `plan-reviewer` only.** It is zero-transform (`tools: Read, Grep, Glob`, no
+  `mcpServers`, no memory in its body, no named skills), so it proves the full
+  pull/render/drift-PR/`.agents-ref` machinery against a clean def with no transform surface.
+  `backlog-manager` is explicitly deferred (see Alternatives) — the acceptance "backlog-manager
+  loads on cloud" moves to `carpet-stain/dotfiles#602`, alongside the hosted-memory transport
+  (ADR-0046) that makes it a _functioning_ cloud agent, not just a loaded one.
+
+## Alternatives considered
+
+- **Push-based sync** (this repo dispatches to every consumer on merge) — rejected: fans a
+  cross-repo write credential across every consumer and needs a producer-side consumer registry
+  that drifts. Pull with a consumer-owned token mirrors how the submodule channel already pulls.
+- **Submodule-in-repo** (a gitlink committed inside the consumer's `.claude/`) — rejected: no
+  guarantee a cloud session's checkout initializes or reads through a gitlink. Plain vendored files
+  at the exact expected path are the only guarantee.
+- **Vendoring `backlog-manager` in v1 with just its `## Memory` section scrubbed** — rejected: its
+  memory-tool instructions are also woven into "Groom on a cadence" and "Project scope" (and
+  softer in its `groom-backlog`/`grilling` skills). A transform that only rewrites the Memory
+  section loads cleanly and then instructs the agent into `mcp__memory` calls whose tool the
+  transform already dropped — the load-time failure `mcpServers`-stripping fixes, reappearing
+  mid-task instead. Faithfully neutralizing it is unbounded, structure-dependent text surgery
+  across the body _and_ its skills — exactly where fragility is worst. Deferred to
+  `carpet-stain/dotfiles#602`, where hosted MCP-over-HTTP memory (ADR-0046) lets the def carry a
+  _hosted_ `mcpServers` endpoint instead — a clean swap, not surgery.
+- **A scheduled cloud canary** (a CI-launched cloud session asserting the def loaded) — rejected:
+  reintroduces the same per-consumer credential fan-out the pull-based inversion eliminated (cloud
+  auth as a new per-consumer secret), plus an unspecified load-readback mechanism. v1's gate is one
+  real, human-run cloud-session verification at vendoring time instead.
+- **A per-consumer manifest naming the hosted agent set** — rejected as premature: v1 derives the
+  hosted set from the `.claude/agents/*.md` basenames already present in the consumer. A manifest
+  returns only if a consumer must host a strict subset of what's present.
+- **Drift guard against floating `main`** — rejected: every unrelated consumer PR would redden the
+  moment any upstream def changes, for consumers who haven't opted into that change yet. The
+  consumer-pinned `.agents-ref` isolates upstream churn to the next scheduled sync.
+
+## Consequences
+
+- Two channels now carry one agent by design: the ADR-0039 submodule (pull-latest `main`) and this
+  vendored copy (pinned to a lagging SHA). They differing by the pin lag is expected, not drift.
+  On a machine that is both source and consumer (dotfiles), the deployed `~/.claude/agents`
+  symlink and the committed `./.claude/agents` vendored copy are two load paths that can
+  legitimately disagree — edit the submodule/source to change behavior, never the vendored copy.
+- Vendored duplication across every consumer repo is the deliberate trade against ADR-0039's
+  single-copy submodule — accepted because it's sync-bot-controlled and drift-guarded, not
+  hand-maintained.
+- `backlog-manager`'s cloud channel and its "functioning" acceptance (not just "loads") track to
+  `carpet-stain/dotfiles#602`.
+- The one unhedgeable risk is external: Anthropic changing what a cloud session loads from a
+  checkout invalidates this ADR's founding fact. No automated canary covers it (see Alternatives);
+  revisit this ADR if that surface fact changes.
+- A future rules-vendoring decision depends on the separate cloud-rules-loading spike; this ADR
+  makes no claim about rules.
+
+Refs: `carpet-stain/dotfiles#597` (deciding issue, 3 plan-review rounds), `carpet-stain/dotfiles`
+ADR-0039 (distribution decision this resolves the pin-deferral of, for the cloud channel only),
+`carpet-stain/dotfiles#582` (Decision 1, the requirement this channel serves),
+`carpet-stain/dotfiles#602` (backlog-manager's cloud channel + hosted-memory transport),
+`carpet-stain/dotfiles` ADR-0046 (hosted memory), ADR-0008 (rules load-all model, why rules are
+out of scope here).

--- a/scripts/render-agent.sh
+++ b/scripts/render-agent.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Renders the cloud-channel "owned carve-out" for a consumer repo: each named
+# agent's persona (skill-closure resolved, cloud-transformed) plus the skills
+# it runs, and the .agents-ref pin. See docs/adr/0002 for the channel this
+# implements (carpet-stain/dotfiles#597).
+#
+# usage:
+#   render-agent.sh --agents-repo <path> --consumer-dir <path> [--check] [agent ...]
+#
+# Without --check: writes <consumer-dir>/agents/<name>.md,
+# <consumer-dir>/skills/<name>/, and <consumer-dir>/.agents-ref (the
+# --agents-repo checkout's HEAD SHA), then exits 0.
+#
+# With --check: renders into a scratch dir and diffs against what's already
+# committed under consumer-dir; no-ops (exit 0) if consumer-dir/.agents-ref
+# is absent — a virgin consumer has nothing vendored yet to check. The
+# caller is responsible for checking --agents-repo out at the SHA recorded
+# in consumer-dir/.agents-ref before invoking --check (issue #597 finding 4:
+# the guard compares against the pinned ref, never floating main).
+#
+# agent names default to the basenames of consumer-dir/agents/*.md already
+# present — the hosted set is derived from presence, never a separate
+# manifest (issue #597 finding 7).
+set -euo pipefail
+
+agents_repo=""
+consumer_dir=""
+check=0
+agent_names=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agents-repo)
+      agents_repo="$2"
+      shift 2
+      ;;
+    --consumer-dir)
+      consumer_dir="$2"
+      shift 2
+      ;;
+    --check)
+      check=1
+      shift
+      ;;
+    *)
+      agent_names+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$agents_repo" || -z "$consumer_dir" ]]; then
+  echo "usage: $0 --agents-repo <path> --consumer-dir <path> [--check] [agent ...]" >&2
+  exit 1
+fi
+
+if [[ $check -eq 1 && ! -f "$consumer_dir/.agents-ref" ]]; then
+  echo "no .agents-ref in $consumer_dir yet — nothing vendored, skipping check."
+  exit 0
+fi
+
+if [[ ${#agent_names[@]} -eq 0 ]]; then
+  for f in "$consumer_dir"/agents/*.md; do
+    [[ -e "$f" ]] || continue
+    agent_names+=("$(basename "${f%.md}")")
+  done
+fi
+
+if [[ ${#agent_names[@]} -eq 0 ]]; then
+  echo "no agents to render (none named, none present in $consumer_dir/agents)."
+  exit 0
+fi
+
+agent_body() {
+  awk 'f { print } /^---$/ { c++; if (c == 2) f = 1 }' "$agents_repo/agents/${1}.md"
+}
+
+# RUN-instructed skills only, never backstop skills — see ADR-0002.
+skill_closure() {
+  local persona_body="$1" name
+  for skill_dir in "$agents_repo"/skills/*/; do
+    [[ -d "$skill_dir" ]] || continue
+    name="$(basename "$skill_dir")"
+    if grep -E "\`${name}\`[[:space:]]+skill" <<<"$persona_body" | grep -qv "backstop"; then
+      echo "$name"
+    fi
+  done
+}
+
+# Strips mcpServers/mcp__memory and rewrites ## Memory — see ADR-0002.
+cloud_transform() {
+  awk '
+    function flush_comments() { for (i = 1; i <= cbuf_n; i++) print cbuf[i]; cbuf_n = 0 }
+    BEGIN { state = 0; cbuf_n = 0; in_mcp = 0; in_memory = 0; memory_seen = 0 }
+    state == 0 {
+      print
+      if ($0 == "---") state = 1
+      next
+    }
+    state == 1 {
+      if (in_mcp) {
+        if ($0 ~ /^[ \t]/ || $0 == "") next
+        in_mcp = 0
+      }
+      if ($0 == "---") { flush_comments(); print; state = 2; next }
+      if ($0 ~ /^mcpServers:/) { cbuf_n = 0; in_mcp = 1; next }
+      if ($0 ~ /^#/) { cbuf[++cbuf_n] = $0; next }
+      flush_comments()
+      if ($0 ~ /^tools:/) {
+        gsub(/, *mcp__memory/, "")
+        gsub(/mcp__memory, */, "")
+        gsub(/^tools: *mcp__memory$/, "tools:")
+      }
+      print
+      next
+    }
+    state == 2 {
+      if (!memory_seen && $0 ~ /^## Memory/) {
+        print
+        print ""
+        print "Memory unavailable on this surface — see #602."
+        in_memory = 1
+        memory_seen = 1
+        next
+      }
+      if (in_memory) {
+        if ($0 ~ /^## /) { in_memory = 0 } else { next }
+      }
+      print
+    }
+  '
+}
+
+render_agent() {
+  local name="$1" out_dir="$2" src skill
+  src="$agents_repo/agents/${name}.md"
+  if [[ ! -f "$src" ]]; then
+    echo "error: no such agent in $agents_repo: $name" >&2
+    exit 1
+  fi
+
+  mkdir -p "$out_dir/agents"
+  cloud_transform <"$src" >"$out_dir/agents/${name}.md"
+
+  while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+    mkdir -p "$out_dir/skills"
+    rm -rf "${out_dir:?}/skills/${skill}"
+    cp -R "$agents_repo/skills/${skill}" "$out_dir/skills/${skill}"
+  done < <(skill_closure "$(agent_body "$name")")
+}
+
+sha="$(git -C "$agents_repo" rev-parse HEAD)"
+
+if [[ $check -eq 1 ]]; then
+  scratch="$(mktemp -d)"
+  trap 'rm -rf "$scratch"' EXIT
+
+  drift=0
+  for name in "${agent_names[@]}"; do
+    render_agent "$name" "$scratch"
+    if ! diff -u "$consumer_dir/agents/${name}.md" "$scratch/agents/${name}.md"; then
+      drift=1
+    fi
+    while IFS= read -r skill; do
+      [[ -z "$skill" ]] && continue
+      if ! diff -rq "$consumer_dir/skills/${skill}" "$scratch/skills/${skill}" >/dev/null 2>&1; then
+        echo "drift: skills/${skill} differs from the renderer's output" >&2
+        drift=1
+      fi
+    done < <(skill_closure "$(agent_body "$name")")
+  done
+
+  if [[ $drift -ne 0 ]]; then
+    echo "::error::vendored .claude carve-out has drifted from the renderer's output at $sha — re-run the sync workflow." >&2
+    exit 1
+  fi
+  echo "carve-out matches pinned ref $sha — no drift."
+  exit 0
+fi
+
+for name in "${agent_names[@]}"; do
+  render_agent "$name" "$consumer_dir"
+done
+echo "$sha" >"$consumer_dir/.agents-ref"


### PR DESCRIPTION
## Summary

Implements steps 1/5/6 of `carpet-stain/dotfiles#597`'s plan-approved decision (3 plan-review
rounds, derivation in that issue's thread):

- `scripts/render-agent.sh` — resolves each named agent's skill closure (persona + RUN-instructed
  skills, excluding backstop skills) and applies the cloud-channel transform (strips `mcpServers`,
  drops `mcp__memory`, rewrites `## Memory`), emitting the owned carve-out
  (`.claude/agents/<name>.md`, `.claude/skills/<name>/`, `.claude/.agents-ref`). Supports `--check`
  for a consumer's drift-guard CI, no-op'ing when `.agents-ref` is absent (virgin consumer).
- `docs/adr/0002-vendored-agent-cloud-channel.md` — records the channel, the alternatives rejected
  along the way (push-based sync, submodule-in-repo, backlog-manager in v1, a cloud canary, a
  manifest, a floating-main drift guard), and resolves ADR-0039's SHA-pin deferral for the cloud
  channel only.
- Filed the gating spike separately: #14 (does a repo-committed rules dir load on cloud, and how).

## Verification

- `./scripts/render-agent.sh --agents-repo . --consumer-dir <scratch> plan-reviewer` renders
  byte-identical output to `agents/plan-reviewer.md` — confirms the transform is a true no-op on a
  zero-transform def.
- `--check` against a clean render exits 0; against a manually-mutated copy, correctly diffs and
  exits 1.
- `--check` against a consumer dir with no `.agents-ref` no-ops (exit 0) — bootstrap case.
- Ran the renderer against `backlog-manager.md` (not vendoring it — just exercising the transform)
  to confirm `mcpServers`/`mcp__memory`/`## Memory` are correctly stripped/rewritten. This also
  reproduces plan-review round 3's finding that backlog-manager's memory calls elsewhere in its
  body (Groom on a cadence, Project scope) survive untouched — confirming why it's out of v1 scope
  rather than a gap in this renderer.
- `shellcheck`/`shfmt`/`prettier`/`markdownlint` all clean; lefthook pre-commit passed.

## Consumer-side work

`carpet-stain/dotfiles#597` also covers the consumer sync workflow, drift-guard CI, and vendoring
`plan-reviewer` into dotfiles' committed `.claude/` — a separate PR in that repo closes #597 once
both halves land.

No-Issue: this repo carries no tracking issue for #597 (it's a `carpet-stain/dotfiles` issue); the
dotfiles-side PR is what closes it.