### PR TITLE
ci(review): fetch the OpenRouter key from SSM via OIDC

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -10,20 +10,37 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:
     runs-on: ubuntu-latest
     steps:
+      - name: Assume OpenRouter SSM read role
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ vars.AWS_OPENROUTER_ROLE_ARN }}
+          aws-region: us-east-1
+
+      # Advisory only: a role-assume or SSM fetch failure skips the review, never fails the job (infra#220).
       - name: Check for the review API key
         id: guard
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "OPENAI_API_KEY not set — advisory review skipped." >&2
+          if [ "${{ steps.aws-creds.outcome }}" != "success" ]; then
+            echo "OIDC role assume failed — advisory review skipped." >&2
+            echo "enabled=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          value="$(aws ssm get-parameter --name /runtime/openrouter-api-key \
+            --with-decryption --query Parameter.Value --output text 2>/dev/null)" || value=""
+          if [ -z "$value" ]; then
+            echo "OPENAI_API_KEY not available from SSM — advisory review skipped." >&2
             echo "enabled=false" >>"$GITHUB_OUTPUT"
           else
+            echo "::add-mask::$value"
+            echo "OPENAI_API_KEY=$value" >>"$GITHUB_ENV"
             echo "enabled=true" >>"$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@v7
@@ -36,7 +53,6 @@ jobs:
         if: steps.guard.outputs.enabled == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_URL: https://openrouter.ai/api/v1/chat/completions
           OPENAI_MODEL: openai/gpt-5.6-sol
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Closes #16

Switches `pr-code-review.yml` from a per-repo `OPENAI_API_KEY` secret (never
set — reviewer was silently no-op'ing) to fetching the key from SSM via the
shared OIDC role `infra#220` vends.

## What changed

- Added `id-token: write`; assume `vars.AWS_OPENROUTER_ROLE_ARN` via
  `aws-actions/configure-aws-credentials` (pinned SHA, matching the
  `infra` repo's own convention for this action).
- Fetch `/runtime/openrouter-api-key` via `aws ssm get-parameter`, mask it,
  export via `GITHUB_ENV`.
- Guard checks `steps.aws-creds.outcome` (not `conclusion`) so a role-assume
  failure is detected even though `continue-on-error: true` keeps the step
  itself green — then degrades cleanly (green job, review skipped, no error)
  on either a role-assume failure or an empty SSM fetch.
- Dropped the `secrets.OPENAI_API_KEY` reference.

## Verification

- `actionlint` and full `just lint` pass locally.
- Confirmed live against this PR's own CI run (32062466825): role assume
  failed (see below), guard correctly read `outcome: failure`, set
  `enabled=false`, and the job finished green with the review step skipped —
  the exact degrade-gracefully behavior the issue's acceptance criteria call
  for.

## Follow-up needed before this is fully live (outside this diff's scope)

`AWS_OPENROUTER_ROLE_ARN` isn't seeded as a repo variable on `agents` yet, so
`role-to-assume` currently resolves empty and the reviewer still no-ops (now
cleanly, not silently). Seed it (repo Settings → Actions → Variables) with
infra's `pr_review_openrouter_read_role_arn` output, then a fresh PR should
exercise the real path: role assume → SSM fetch → an actual review comment.
Journaled in the PR thread as it was found.