### PR TITLE
ci(adr-guard): drop the labeled/unlabeled trigger

### DIFF
--- a/.github/workflows/adr-guard.yml
+++ b/.github/workflows/adr-guard.yml
@@ -4,9 +4,9 @@ name: ADR guard
 # unrecorded. Checks presence only (label is a human call) — see docs/adr/README.md.
 on:
   pull_request:
-    # labeled/unlabeled so applying or removing the label re-evaluates the gate;
-    # the rest match pr-guards.yml.
-    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    # Same types as pr-guards.yml. No labeled/unlabeled: they re-ran this on
+    # every label change; the label-a-green-PR-then-merge gap is accepted (carpet-stain/project-starter-template#95).
+    types: [opened, reopened, synchronize, ready_for_review]
     branches: ["main"]
 
 permissions:


### PR DESCRIPTION
Drops `labeled, unlabeled` from adr-guard.yml's `pull_request` types and updates the justifying comment. Those types re-ran the guard on every label change; the accepted tradeoff is that labeling an already-green PR no longer re-evaluates the gate — fine here, since the labeler is the ADR author and the ADR commit re-triggers the guard. Mirrors carpet-stain/project-starter-template#103.

No-Issue: epic checklist item — carpet-stain/project-starter-template#95 tracks the rollout and must stay open
