### PR TITLE
ci(reusable): switch guards to thin reusable-workflow callers

### DIFF
--- a/.github/workflows/adr-guard.yml
+++ b/.github/workflows/adr-guard.yml
@@ -1,11 +1,9 @@
 name: ADR guard
 
-# Architecture-labeled PRs must touch docs/adr/, or the decision goes
-# unrecorded. Checks presence only (label is a human call) — see docs/adr/README.md.
+# Thin caller — the guard body lives in the template source repo's
+# reusable-adr-guard.yml (its ADR-0004); Dependabot bumps the SHA pin.
 on:
   pull_request:
-    # Same types as pr-guards.yml. No labeled/unlabeled: they re-ran this on
-    # every label change; the label-a-green-PR-then-merge gap is accepted (carpet-stain/project-starter-template#95).
     types: [opened, reopened, synchronize, ready_for_review]
     branches: ["main"]
 
@@ -17,31 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  adr-guard:
-    name: adr guard
-    runs-on: ubuntu-latest
-    # Job-level if, not workflow-level: a workflow-level skip reads as passing to
-    # required-status-check branch protection. Stays quiet on drafts, fires at ready_for_review.
-    if: github.event.pull_request.draft == false
-    steps:
-      # Step-level if, not job-level: a required check must always report a
-      # conclusion, or a skipped run sits pending forever and blocks merge.
-      - uses: actions/checkout@v7
-        if: contains(github.event.pull_request.labels.*.name, 'architecture')
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Require a docs/adr/ touch on architecture-labeled PRs
-        if: contains(github.event.pull_request.labels.*.name, 'architecture')
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-        run: |
-          # Three-dot: diff from the merge-base, so only files this PR changed
-          # count — not files the base branch changed after the PR forked.
-          if git diff --name-only "$BASE"...HEAD | grep -q '^docs/adr/'; then
-            echo "architecture-labeled PR touches docs/adr/ — ok."
-          else
-            echo "::error::PR is labeled 'architecture' but adds/modifies no docs/adr/ file. Record the decision as an ADR (see docs/adr/README.md) before merge."
-            exit 1
-          fi
+  # Job id `guards` is ruleset contract: the required context is
+  # `guards / adr guard` — renaming this id breaks the ruleset.
+  guards:
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-adr-guard.yml@504d81a0dca5b0e67d7756610cf22b49b2be7ddf # main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
-# Language-agnostic linters only (lefthook `base` tag); an overlay ships its
-# own workflow/tag/toolchain instead. Disjoint file ownership — see ADR-0020.
+# Thin caller — the lint body lives in the template source repo's
+# reusable-lint.yml (its ADR-0004); Dependabot bumps the SHA pin.
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -15,61 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    # Job-level if, not workflow-level: a workflow-level skip reads as passing to
-    # required-status-check branch protection. Same gate as pr-guards.yml.
-    if: github.event.pull_request.draft == false
-    steps:
-      - uses: actions/checkout@v7
-
-      # Portable toolchain, no Homebrew (#276): install each linter its native way
-      # instead of assuming Homebrew. `just lint` still drives the shared lefthook.
-      - uses: actions/setup-node@v7
-        with:
-          node-version: lts/*
-      - name: Install Node lint tools
-        run: npm install --global lefthook markdownlint-cli2 prettier
-
-      - uses: extractions/setup-just@v4
-
-      - name: Install actionlint and yamlfmt
-        env:
-          ACTIONLINT_VERSION: "1.7.12"
-          YAMLFMT_VERSION: "0.21.0"
-        run: |
-          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin actionlint
-          curl -fsSL "https://github.com/google/yamlfmt/releases/download/v${YAMLFMT_VERSION}/yamlfmt_${YAMLFMT_VERSION}_Linux_x86_64.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin yamlfmt
-
-      - name: Install gitleaks
-        env:
-          GITLEAKS_VERSION: "8.30.1"
-        run: |
-          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin gitleaks
-
-      - name: Install shfmt and shellcheck
-        env:
-          SHFMT_VERSION: "3.13.1"
-          SHELLCHECK_VERSION: "0.11.0"
-        run: |
-          curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-            -o /tmp/shfmt && sudo install -m 755 /tmp/shfmt /usr/local/bin/shfmt
-          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-            | sudo tar -xJ -C /usr/local/bin --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
-
-      - name: Install editorconfig-checker
-        env:
-          EDITORCONFIG_CHECKER_VERSION: "3.8.0"
-        run: |
-          curl -fsSL "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v${EDITORCONFIG_CHECKER_VERSION}/ec-linux-amd64.tar.gz" \
-            | tar -xz -O bin/ec-linux-amd64 | sudo tee /usr/local/bin/editorconfig-checker > /dev/null
-          sudo chmod +x /usr/local/bin/editorconfig-checker
-
-      # `just lint` is the same entry point contributors run locally, scoped
-      # here to the base tag; the untagged local run covers the full union.
-      - name: Run lint/format checks
-        run: just lint --tag base --no-tty
+  # Job id `guards` matches the other callers; context: `guards / lint`.
+  guards:
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-lint.yml@504d81a0dca5b0e67d7756610cf22b49b2be7ddf # main

--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -1,7 +1,7 @@
 name: PR guards
 
-# Enforces one-commit-per-PR + rebase-merge (AGENTS.md): a single Conventional
-# Commit subject, and it closes an issue or declares why not (dotfiles#449).
+# Thin caller — the guard bodies live in the template source repo's
+# reusable-pr-guards.yml (its ADR-0004); Dependabot bumps the SHA pin.
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -16,91 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  single-commit:
-    name: single commit
-    runs-on: ubuntu-latest
-    # Job-level if, not workflow-level: a workflow-level skip reads as passing to
-    # required-status-check branch protection. Stays quiet on drafts, fires at ready_for_review.
-    if: github.event.pull_request.draft == false
-    steps:
-      - name: Assert the PR is exactly one commit
-        env:
-          COMMITS: ${{ github.event.pull_request.commits }}
-        run: |
-          if [ "$COMMITS" -ne 1 ]; then
-            echo "::error::PR has $COMMITS commits; squash to exactly one before merge (git rebase origin/main && git reset --soft origin/main && git commit)."
-            exit 1
-          fi
-          echo "PR is a single commit."
-
-  conventional-commit:
-    name: conventional commit
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      # git-cliff reads this commit's subject for the changelog, so it must be
-      # a Conventional Commit; scope stays optional/unrestricted.
-      - name: Validate Conventional Commit subject
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-        run: |
-          rc=0
-          for sha in $(git rev-list "$BASE"..HEAD); do
-            subject=$(git log -1 --format=%s "$sha")
-            if echo "$subject" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z0-9._-]+\))?!?: .+'; then
-              echo "ok: $subject"
-            else
-              echo "::error::not a Conventional Commit: $subject"
-              rc=1
-            fi
-          done
-          exit $rc
-
-  issue-link:
-    name: issue link
-    runs-on: ubuntu-latest
-    # release-prepare.yml's release/* PRs close no issue by design — exempted
-    # here in-guard so the whole contract stays in this one file (dotfiles#449).
-    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.head.ref, 'release/')
-    steps:
-      # GitHub's computed closingIssuesReferences (dotfiles#449), not a body
-      # regex, so a typo'd closing keyword that never actually linked fails this check.
-      - name: Require a closing issue reference or a No-Issue marker
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          # shellcheck disable=SC2016 # single-quoted GraphQL vars, not bash
-          # ($owner/$repo/$number passed via -f/-F below).
-          count=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $number) {
-                  closingIssuesReferences { totalCount }
-                }
-              }
-            }' -f owner="$OWNER" -f repo="$REPO" -F number="$PR_NUMBER" \
-            --jq '.data.repository.pullRequest.closingIssuesReferences.totalCount')
-
-          if [ "$count" -gt 0 ]; then
-            echo "closes $count issue(s) — ok."
-            exit 0
-          fi
-
-          # GNU grep \s/\S here, not dotfiles#449's POSIX space class: that
-          # class's double square brackets collide with this template's jinja delimiter.
-          if echo "$PR_BODY" | grep -qE '^No-Issue:\s*\S'; then
-            echo "No-Issue marker present — ok."
-            exit 0
-          fi
-
-          echo "::error::PR closes no issue and has no No-Issue: marker. Add \`Closes #N\` to the body, or a \`No-Issue: <reason>\` line."
-          exit 1
+  # Job id `guards` is ruleset contract: required contexts are
+  # `guards / single commit` etc. — renaming this id breaks the ruleset.
+  guards:
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-pr-guards.yml@504d81a0dca5b0e67d7756610cf22b49b2be7ddf # main


### PR DESCRIPTION
**DO NOT MERGE YET — draft is deliberate.** Merging before infra flips this repo's `reusable_guards` ruleset contexts (carpet-stain/infra#259 pattern) to the `guards / <job>` names strands the repo's required checks: the old contexts never report again and every PR blocks.

Converts adr-guard.yml, pr-guards.yml, and lint.yml to thin callers of carpet-stain/project-starter-template's reusable workflows, SHA-pinned to `504d81a` (main). Phase 1 of carpet-stain/project-starter-template#104. Triggers, permissions, and concurrency groups are unchanged; job id `guards` is the ruleset contract, so contexts become `guards / adr guard`, `guards / single commit`, `guards / conventional commit`, `guards / issue link`, `guards / lint`.

Verified with actionlint on each edited file.

No-Issue: epic checklist item — carpet-stain/project-starter-template#104 tracks the rollout and must stay open
