### PR TITLE
ci(reusable): pin the shared-guard callers to the moving v1 tag

### DIFF
--- a/.github/workflows/adr-guard.yml
+++ b/.github/workflows/adr-guard.yml
@@ -1,7 +1,7 @@
 name: ADR guard
 
 # Thin caller — the guard body lives in the template source repo's
-# reusable-adr-guard.yml (its ADR-0004); Dependabot bumps the SHA pin.
+# reusable-adr-guard.yml (its ADR-0004) — pinned to its moving major tag (its #110).
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -18,4 +18,4 @@ jobs:
   # Job id `guards` is ruleset contract: the required context is
   # `guards / adr guard` — renaming this id breaks the ruleset.
   guards:
-    uses: carpet-stain/project-starter-template/.github/workflows/reusable-adr-guard.yml@504d81a0dca5b0e67d7756610cf22b49b2be7ddf # main
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-adr-guard.yml@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 # Thin caller — the lint body lives in the template source repo's
-# reusable-lint.yml (its ADR-0004); Dependabot bumps the SHA pin.
+# reusable-lint.yml (its ADR-0004) — pinned to its moving major tag (its #110).
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -17,4 +17,4 @@ concurrency:
 jobs:
   # Job id `guards` matches the other callers; context: `guards / lint`.
   guards:
-    uses: carpet-stain/project-starter-template/.github/workflows/reusable-lint.yml@504d81a0dca5b0e67d7756610cf22b49b2be7ddf # main
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-lint.yml@v1

--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -1,7 +1,7 @@
 name: PR guards
 
 # Thin caller — the guard bodies live in the template source repo's
-# reusable-pr-guards.yml (its ADR-0004); Dependabot bumps the SHA pin.
+# reusable-pr-guards.yml (its ADR-0004) — pinned to its moving major tag (its #110).
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -19,4 +19,4 @@ jobs:
   # Job id `guards` is ruleset contract: required contexts are
   # `guards / single commit` etc. — renaming this id breaks the ruleset.
   guards:
-    uses: carpet-stain/project-starter-template/.github/workflows/reusable-pr-guards.yml@504d81a0dca5b0e67d7756610cf22b49b2be7ddf # main
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-pr-guards.yml@v1


### PR DESCRIPTION
Part of carpet-stain/project-starter-template#110: SHA pins → the moving `@v1` major tag. Compatible guard changes then propagate with zero bump PRs; breaking caller-contract changes cut `v2` upstream (pst ADR-0004 as amended).

**Draft until pst's `v1` tag exists** (pst#111's post-merge release cuts it) — `@v1` is unresolvable before that and these callers startup-fail, including on this PR's own checks. Once the tag exists, re-run checks and ready+merge; no ruleset implications (check names unchanged).

No-Issue: consumer checklist item — carpet-stain/project-starter-template#110 tracks the sweep and must stay open