### PR TITLE
fix(claude): pin server-memory MCP dependency version

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -27,7 +27,7 @@ mcpServers:
         - >-
           mkdir -p "$HOME/.claude/agent-memory-mcp" &&
           MEMORY_FILE_PATH="$HOME/.claude/agent-memory-mcp/backlog-manager.jsonl"
-          exec npx -y @modelcontextprotocol/server-memory
+          exec npx -y @modelcontextprotocol/server-memory@2026.7.4
 # Judgment-heavy role: capable model, medium effort as the cost control (see
 # rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").
 model: claude-opus-4-8


### PR DESCRIPTION
## Summary

`npx -y @modelcontextprotocol/server-memory` in backlog-manager's
frontmatter `mcpServers:` wiring resolved the floating latest on every
invocation — an upstream release could change the memory server's
behavior under us with no review. Pin to `2026.7.4`, the version npm
currently resolves as latest, so a future bump is a reviewed diff instead
of a silent one.

## Verification

- `agents/backlog-manager.md`'s `mcpServers.memory` command now pins
  `@modelcontextprotocol/server-memory@2026.7.4` instead of the floating
  tag.
- No other file references the unpinned package (checked
  `docs/`/`README.md` — the README's prose mention has no version number
  to pin).

Closes carpet-stain/dotfiles#637