### PR TITLE
docs(implement-issue): note branch naming is unconstrained for token-cost keying

### DIFF
--- a/skills/implement-issue/SKILL.md
+++ b/skills/implement-issue/SKILL.md
@@ -41,7 +41,9 @@ opening PRs live in the repo's own git workflow doc — this skill doesn't resta
    diff. The PR description and comments stay terse by the same discipline.
 7. **Record token cost, if this repo tracks it.** Check AGENTS.md for a per-issue token-accounting
    step (a `just`/script recipe keyed by the issue number) and run it before finalizing. Purely
-   repo-specific — skip silently where none is defined.
+   repo-specific — skip silently where none is defined. Branch naming is unconstrained for this —
+   `issue-N`/`fix-N` only buys cleaner keying, not a requirement, since the recording script falls
+   back to the current branch when the issue-number lookup misses (carpet-stain/dotfiles#664).
 8. **At finalize, hand off.** Apply the repo's PR handoff rule if it states one (self-sufficient
    top post, journal as optional depth) — rewrite the PR body to stand alone before flipping ready.
    Stop there. Flipping the PR to ready-for-review is the handoff; merging is someone else's call.


### PR DESCRIPTION
## Summary

`implement-issue`'s step 7 (token-cost recording) is where a reader would look to see if branch naming matters for that step to succeed. Adds a one-line note: it doesn't — `issue-N`/`fix-N` only buys cleaner keying, dotfiles#664 made the accounting script fall back to the current branch when the issue-number lookup misses. Preventive, per the issue: step 3 makes no naming claim today, so nothing there needed correcting.

## Test plan

- [x] `lefthook run pre-commit` green (md-format, markdownlint, gitleaks, editorconfig, envrc-sync)

Closes #25
