### PR TITLE
docs(backlog-manager): record the hosted-invocation guard on Agent(plan-reviewer)

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -168,6 +168,12 @@ convention, not universal. It runs best from a dedicated `claude --agent backlog
 there you're the main thread, so you can delegate to the `plan-reviewer` subagent directly (that's
 what the scoped `Agent(plan-reviewer)` tool is for).
 
+**This nested-subagent path is a local-session convenience only.** Under hosted/headless
+invocation, cross-role turns are substrate-mediated instead, never a nested subagent call
+(carpet-stain/dotfiles ADR-0048, Decision 3 in dotfiles#582) — the hosted runner strips this tool
+at spawn time (`--disallowedTools "Agent"`, dotfiles' `agent-runner.yml`) so the retired interim
+can't fire there. Don't rely on `Agent(plan-reviewer)` being available outside a local session.
+
 When you file a new issue live, in direct response to the current conversation, and it qualifies
 for the gate, draft the plan and kick off the plan-reviewer loop in the same pass — don't wait for
 a separate "run it now" prompt; you already have the context. A grooming sweep turning up an old,


### PR DESCRIPTION
## Summary

Resolves the spike: **the mechanism decision is confirmed as a runtime guard**, already implemented in dotfiles' `agent-runner.yml` — `--disallowedTools "Agent"` at spawn time when the role is `backlog-manager`, chosen there specifically because `backlog-manager.md` is submodule-owned and out of that repo's write scope. This PR records that decision in the definition itself, since this repo *can* own that note.

Considered and rejected (per the maintainer's call on the spike):
- **Split into a separate hosted-only agent variant** — no reliance on an unverified CLI flag, but two definitions to keep in sync.
- **Accept the risk, do nothing** — cheapest, but leaves Decision 3's exact failure mode untested.

## Follow-up filed

The guard is flagged unverified upstream in `agent-runner.yml`'s own comment (whether `--disallowedTools` actually overrides an `--agent`'s frontmatter tools list). Filed carpet-stain/dotfiles#700 to verify it empirically rather than assume it holds.

## Test plan

- [x] `lefthook run pre-commit` green (md-format, markdownlint, gitleaks, editorconfig, envrc-sync)

Closes #28
