### PR TITLE
feat(plan-reviewer): add a scoped read-only GitHub tool

### DIFF
--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -7,7 +7,21 @@ description: >-
   scope creep, and simpler alternatives. Use proactively before committing to any non-trivial
   plan, design, or refactor. Not for reviewing finished code diffs (that's `/code-review`), and
   it never writes code or files — it only critiques.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__github
+# Read-only GitHub tool (agents#27, mechanism/scope there). $GITHUB_PERSONAL_ACCESS_TOKEN
+# must come from the invoking shell, not this env: block — it doesn't expand vars (#542).
+mcpServers:
+  - github:
+      type: stdio
+      command: /bin/sh
+      args:
+        - -c
+        - >-
+          exec docker run -i --rm
+          -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN"
+          -e GITHUB_READ_ONLY=1
+          -e GITHUB_TOOLSETS=context,issues
+          ghcr.io/github/github-mcp-server:v1.10.1
 # Judgment-heavy role: capable model, medium effort as the cost control (see
 # rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").
 model: claude-opus-4-8
@@ -26,7 +40,9 @@ obvious-in-hindsight only from outside.
 
 You are **read-only**. You never write or edit code, never implement, never open a PR. Your one
 artifact is the critique. Write/Edit aren't in your tool surface — treat that as a structural
-guarantee, not a reminder.
+guarantee, not a reminder. The scoped `mcp__github` tool (when connected) only reads — it can't
+comment, label, or edit anything either; the read-only guarantee covers GitHub state too, not
+just the filesystem.
 
 ## Ground yourself before critiquing
 
@@ -37,6 +53,11 @@ A review that ignores how this repo actually works is noise. Before judging a pl
   constraint) is a finding; one that follows it is not yours to relitigate.
 - Verify the plan's claims against the real code, not its description of the code. If it says "X
   already handles this," open X and check. Assume the plan is wrong until the repo shows it right.
+- When invoked directly against a live issue rather than a fed-in thread, use `mcp__github` to
+  read it yourself instead of asking the invoker to paste state you could fetch — pasted context
+  goes stale the moment a new comment lands. If the tool isn't connected (no container runtime
+  available), fall back to whatever's fed into the prompt; say so rather than guessing at missing
+  context.
 
 Repo-agnostic: read the conventions here at runtime; never assume another repo's.
 


### PR DESCRIPTION
## Summary

Resolves the spike: plan-reviewer gets a scoped, read-only GitHub tool instead of staying strictly fed-context. dotfiles ADR-0051 explicitly deferred this exact question here rather than deciding it — this closes that loop.

- **Mechanism**: `github/github-mcp-server` via Docker (no npm distribution exists), wired as `mcp__github` in frontmatter, with `GITHUB_READ_ONLY=1` + `GITHUB_TOOLSETS=context,issues`.
- **Verified locally, not assumed**: `tools/list` returns exactly `issue_read`, `list_issues`, `search_issues`, `get_me`, `get_label`, `list_issue_fields`, `list_issue_types`, `get_teams`, `get_team_members` — no write tool present at all, confirming read-only mode actually shrinks the tool surface rather than just gating individual calls. A real `issue_read` against carpet-stain/dotfiles#668 round-tripped its full body correctly.
- **Structural guarantee preserved**: the role still has no Write/Edit, and the new tool can't comment/label/edit either — read-only now covers GitHub state, not just the filesystem.
- **Credential**: the invoking shell's own `$GITHUB_PERSONAL_ACCESS_TOKEN` — no new credential type needed for local use, since read-only issue access doesn't need a dedicated scoped PAT. The frontmatter's `env:` block does **not** expand shell variables (the same lesson `backlog-manager.md`'s `$HOME` wiring already hit, agents#... / dotfiles#542) — substitution happens in the `/bin/sh -c` wrapper instead, not there.
- **Graceful degradation**: confirmed against Claude Code's own docs — a machine without a running container runtime just doesn't get this tool that session (falls back to fed-context, today's behavior), not a hard failure.

## Follow-up filed

Hosted wiring (threading plan-reviewer's already-provisioned PAT into `agent-runner.yml`'s spawn step, updating its now-stale "never reads GitHub itself" comment, and a short ADR-0051 addendum) is a separate dotfiles change — filed as [dotfiles#710](https://github.com/carpet-stain/dotfiles/issues/710) since that workflow lives in a different repo.

## Test plan

- [x] `lefthook run pre-commit` green (md-format, markdownlint, gitleaks, editorconfig, envrc-sync)
- [x] Local `docker run` smoke test: image pulls, `--version` runs, full MCP stdio handshake (`initialize` → `tools/list` → `tools/call issue_read`) succeeds against a real issue

Closes #27
