### PR TITLE
feat(grilling): batch questions by dependency frontier

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ fires on request or it doesn't, there's nothing to self-gate against a repo's sh
 - **`audit-memory`** — read-only audit of a project-manager subagent's MCP knowledge-graph memory
   for staleness against live GitHub state, one-home duplication, and broken graph structure. The
   detection backstop to that subagent's own write-time contract, wherever it's defined.
-- **`grilling`** — extracts decisions one at a time before committing to a plan, instead of guessing
-  a batch of assumptions, for genuinely undecided scope.
+- **`grilling`** — extracts decisions in dependency order before committing to a plan, instead of
+  guessing a batch of assumptions: each round asks the frontier of settled-prerequisite questions,
+  for genuinely undecided scope.
 - **`groom-backlog`** — the periodic backlog-sweep procedure: untriaged issues, priority re-weigh,
   dedup, weak-issue tightening, label drift, epic-child verification.
 - **`implement-issue`** — a worker-session ritual for implementing a single shaped GitHub issue end

--- a/skills/grilling/SKILL.md
+++ b/skills/grilling/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: grilling
 description: >-
-  Extracts decisions one at a time before committing to a plan, instead of guessing a batch of
-  assumptions. Looks up anything discoverable in the environment itself rather than asking; puts
-  each real decision to the human as a single question with a recommended answer, and doesn't act
-  until it's confirmed. Use when scope, structure, or approach is genuinely undecided and guessing
-  would waste a round — shaping a new epic, splitting an overgrown issue, defining a spike's
-  question and deliverable, weighing a spike's verdict, or pre-gating an issue with thin
-  acceptance criteria. Not for routine, already-clear work.
+  Extracts decisions in dependency order before committing to a plan, instead of guessing a
+  batch of assumptions. Maps the open decisions as a design tree and asks each round's
+  frontier — every question whose prerequisites are settled — with a recommended answer per
+  question; looks up anything discoverable in the environment itself rather than asking, and
+  doesn't act until the frontier is empty. Use when scope, structure, or approach is genuinely
+  undecided and guessing would waste a round — shaping a new epic, splitting an overgrown
+  issue, defining a spike's question and deliverable, weighing a spike's verdict, or pre-gating
+  an issue with thin acceptance criteria. Not for routine, already-clear work.
 ---
 
 # Grilling
@@ -15,21 +16,37 @@ description: >-
 A protocol for extracting decisions, not a form to fill out. The failure mode this replaces:
 guessing a batch of assumptions up front and burning a round when one is wrong.
 
+Map the open decisions as a **design tree** — every decision branches into the decisions that
+hang off it — and work it in **rounds**. The **frontier** is every decision whose prerequisites
+are already settled: the questions askable now without guessing at answers not yet heard.
+
 ## Rules
 
-1. **Look it up before you ask.** Anything discoverable from the environment — an existing file,
-   a label taxonomy, a past decision in memory, prior art in the repo — isn't a question. Read it.
-2. **One question at a time.** Ask, wait, incorporate the answer, ask the next. Never a numbered
-   batch of unrelated questions in one message — each answer can change what's worth asking next.
-3. **Every question carries a recommendation.** State the decision, your recommended answer, and
-   why in one or two sentences. The human is confirming or redirecting a specific call, not
+1. **Facts are yours; decisions are the human's.** Anything discoverable from the
+   environment — an existing file, a label taxonomy, a past decision in memory, prior art in
+   the repo — isn't a question. Look it up. When a lookup is long-running, dispatch a subagent
+   and don't block the round on it: only the questions downstream of its answer wait; ask the
+   rest of the frontier now.
+2. **Ask the whole frontier each round — and nothing past it.** A question whose answer depends
+   on another question still open this round belongs to a later round, not this one. Then wait:
+   each round's answers reshape the tree, settle prerequisites, and push the frontier outward.
+   Recompute and ask the next round.
+3. **Every question carries a recommendation.** State the decision, your recommended answer,
+   and why in a sentence or two. The human is confirming or redirecting a specific call, not
    opening a blank design discussion.
-4. **Don't act until confirmed.** No drafting the epic body, splitting the issue, or writing the
-   plan ahead of the answer — grilling ends when the open decisions run out, not when you get
-   tired of asking.
+
+   ```text
+   ❓ **Q1** — **<decision title>**: <the question, choices included where they help>
+
+   ➡️ <recommended answer, with the why>
+   ```
+
+4. **Don't act until the frontier is empty.** No drafting the epic body, splitting the issue,
+   or writing the plan while any decision is open — grilling ends when the tree is fully
+   visited, not when you get tired of asking.
 
 ## When to stop
 
-Once every genuinely open decision has an answer, the interview is done — hand off to whatever
-comes next (drafting the epic, writing the split, defining the spike). Don't manufacture more
-questions once nothing is actually undecided.
+An empty frontier ends the interview: every branch visited, nothing left silently assumed —
+hand off to whatever comes next (drafting the epic, writing the split, defining the spike).
+Don't manufacture questions once nothing is actually undecided.


### PR DESCRIPTION
Rewrites the grilling skill from strict one-question-at-a-time to upstream's frontier-batched model (mattpocock/skills `productivity/grilling`, the skill's origin, which has moved on since our 2026-07 snapshot): map the open decisions as a design tree, ask each round's frontier — every question whose prerequisites are already settled — each with a recommended answer, recompute after the answers land, stop when the frontier is empty.

Why the batch model fits here: the plans grilling feeds go through the adversarial plan-review loop. Grilling extracts decisions (the human's preferences — review can't recover a wrong one, so no question gets skipped), but serial's insurance premium — one human round per question so no question is ever asked on a stale premise — pays for coherence the reviewer loop re-buys downstream anyway. Batching spends human rounds on breadth and leaves soft-dependency slips to the reviewer, at agent cost. Frontier discipline keeps the original anti-guessing rationale (#470's motivation): only settled-prerequisite questions batch, hard dependencies still wait their round.

Also folded in from upstream: async fact-finding (a long-running lookup dispatches a subagent; only its downstream questions wait — the rest of the frontier goes out now).

Deliberately kept ours: the when-to-use trigger list in the frontmatter description, verbatim — backlog-manager's grill-by-default section points at it as the one home for triggers. Upstream's `grill-me`/`grill-with-docs` companions not adopted (manual-trigger shims + a domain-modeling glossary/ADR format that conflicts with our governed ADR template).

README's one-line skill summary updated to match.

Verification: `just lint` green (markdownlint fenced-block language tag included).
