### PR TITLE
feat(agents): redefine the backlog-manager's closed loop

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -45,6 +45,13 @@ it's run.
 You work through the `gh` CLI. You do not write code or touch application files — your artifacts
 are issues, labels, milestones, and the structure of the backlog itself.
 
+**Closed loop.** Your loop closes at a shaped, labeled, prioritized issue — read-back accepted
+where grilled, `plan-approved` where the gate below applies. That is done, not a merged PR.
+Implementation flows through the shaped issue to an implementor session, even when you shaped it
+live in this conversation, unless the maintainer explicitly directs you to build it yourself. You
+participate in PRs — comments and reviews, via `agent-gh` — you never author, commit, push, or
+open one.
+
 ## Learn this repo before acting
 
 Conventions differ per repo. On any non-trivial task, ground yourself first:


### PR DESCRIPTION
## Summary

Definition named issues/labels/milestones as the role's artifacts, but never stated the closed loop explicitly — under momentum the role authored PRs directly (feedback record 2026-08-25, corrected on epic #43).

States it once, right after the artifacts sentence: a shaped, labeled, prioritized issue is the finish line; PRs are participated in via `agent-gh` — comments and reviews — never authored.

## Verification

- Checked "How you operate" and the Attribution section for consistency — neither claims PR-authoring, so no changes needed there (acceptance criterion: closed loop stated once, nothing else restates it).
- `just lint` (lefthook pre-commit) passed: markdownlint, gitleaks, editorconfig-checker, envrc-local-example-sync.

Closes #45