### PR TITLE
docs(operating-model): reconcile with the signed roster charters

### DIFF
--- a/docs/adr/0003-enforcement-ladder.md
+++ b/docs/adr/0003-enforcement-ladder.md
@@ -1,0 +1,73 @@
+# 3. The enforcement ladder — shift rules left, prose last
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+The roster audits (agents#53) produced dozens of rules and boundaries needing enforcement, and
+the operating model already held the two endpoints — a deterministic gate beats an agent
+("Deterministic work stays deterministic"), and a forcing function beats prose — with no ordered
+priority between them. Each audit made the placement call ad hoc. The same arc also surfaced the
+underlying principle nobody had written: incorporating agents leaves the SDLC intact — the
+process doesn't change, the seats do — but gaps a human contributor covered implicitly (judgment
+at merge, a glance at CI, "someone would notice") don't get absorbed by an agent the way a human
+absorbs them. Every such gap must be surfaced and explicitly covered. The audits' mode-dependent
+cells were this principle discovered empirically: role-mode must construct every gate skill-mode
+got free from the human session (agents#55).
+
+## Decision
+
+When a rule needs enforcing, implement it at the highest rung it can reach, in order:
+
+1. **Substrate-native** — GitHub rulesets, native review/merge mechanics, required CI checks.
+2. **Third-party tooling** — software purpose-built for the check: lefthook, gitleaks, linters.
+3. **Own code** — scripts this repo writes and maintains (`scripts/`).
+4. **Agent hooks** — PreToolUse and kin triggering scripts at the agent boundary.
+5. **Model judgment in a gate** — an agent verdict wired to a substrate enforcement point (the
+   blocking code-reviewer's request-changes behind branch protection, the plan gate's labels):
+   for rules that need judgment but deserve teeth. Judgment rules are not condemned to prose.
+6. **Prose** — a rule in a definition or doc: the last resort, and the only rung that drifts
+   silently. Where prevention is out of reach, prose plus a deterministic **detection backstop**
+   (an audit skill, a sweep, a drift check) beats bare prose — each rung can fire at prevention
+   time or detection time, and prevention beats detection beats hope.
+
+Shift enforcement left into infrastructure; hand it to software built for the job; build our own
+only when none exists; write prose only when nothing can execute or check the rule. A rule
+sitting on a lower rung than it could reach is a standing defect — where **"could reach" means
+worth reaching**: rung choice weighs violation frequency × consequence against build-and-maintain
+cost (the D6 inventory-review waive in agents#54 is this valve applied). Every placement also
+names its **failure semantics** — fail-open or fail-closed, chosen by whether a false block or a
+false pass is the expensive error (required CI fails closed; a down reviewer fails open,
+agents#57).
+
+Corollary: **the SDLC is invariant; the gaps get named.** Adding an agent to a seat never changes
+the process — it removes the ambient human coverage the seat silently provided, and each uncovered
+gap gets an explicit home on a rung (or a named human gate) before the seat is considered filled.
+
+## Alternatives considered
+
+- **Prose-first (write the rule, mechanize later)** — rejected: prose is the rung that drifts
+  silently, and "later" reliably never comes; the roster audits found three independently
+  hand-rolled copies of one rule (agents#61) — the drift is observed, not hypothetical.
+- **Agent-hooks-first (enforce at the agent boundary)** — rejected: hooks bind only the agent
+  that runs them, cost tokens, and constrain nothing a human or another tool does; a ruleset or
+  CI check binds every actor identically.
+- **No ladder (case-by-case judgment)** — rejected: that was the status quo during the audits;
+  it works but re-litigates placement every time, which is what a recorded decision exists to end.
+
+Provider-agnosticism note: rung 1 deliberately couples enforcement wiring to the substrate while
+the operating model keeps content provider-neutral. No contradiction — enforcement is transport,
+not content: the rule stays portable, its wiring is substrate-local and gets rebuilt on a
+substrate move.
+
+## Consequences
+
+Designs get measured against the ladder (the design framework's D1/D4 audit questions read
+against it); an enforcement idea arrives with its rung named. Building on rungs 1–3 costs more
+up front than prose and pays it back in drift immunity. Revisit if a substrate change moves a
+rung's ceiling — a new native primitive can obsolete own-code overnight (the code-reviewer's
+native review-request did exactly that, agents#57).

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -16,6 +16,12 @@ over them, not a second copy — it cites, it doesn't restate. Sections are tagg
 unattended — but nothing they produce has irreversible effect until a human approves and merges.
 Every agent, every mode. This is the fixed point the rest hangs off.
 
+**[Directional] trajectory, decided at charter (agents#55/#57):** the invariant's merge leg is
+substrate policy — the recorded intent is a future flip to auto-merge for spec-verified work,
+gated by a blocking code-reviewer. The flip ships as a ruleset change plus superseding ADRs
+(ADR-0025's advisory clause via agents#67; this invariant's merge leg via an ADR at flip time).
+Until those land, the invariant binds unchanged.
+
 ## Identity, authorship, voice — [Decided]
 
 Each agent is a first-class team identity (`implementor`, `backlog-manager`, `plan-reviewer`, …),
@@ -27,10 +33,14 @@ same honesty as `author = agent`.
 → dotfiles ADR-0035 (named identities), ADR-0037 (read as AI), ADR-0038 (author/ship split),
 dotfiles#544.
 
-## Memory is the moat — per role, not pooled — [Decided]
+## The edge is per-role — memory is the backlog-manager's moat — [Decided]
 
-A team agent beats a dev's private session on exactly one axis a cold session can't replicate:
-**accumulated memory**. A persona without it is a sock puppet. That memory is owned **per role**,
+A team agent beats a dev's private session on a structural edge a cold session can't replicate —
+and the roster audits (agents#53) showed the edge differs per role: **accumulated memory** (the
+backlog-manager), **separate-context independence** (plan-reviewer and code-reviewer — both
+deliberately store-less; the thread is their memory, reaffirmed at charter in agents#56/#57),
+**holding the gate** (the blocking code-reviewer). A persona without _an_ edge is a sock puppet.
+Where a role's memory exists, it is owned **per role**,
 never shared across roles — each agent has a private, role-scoped store with its own credentials, so
 read/write scoping holds by construction with no enforcement layer to build. The shared record
 _across_ roles is the GitHub artifacts themselves: **issue body = destination, thread = journey**,
@@ -40,7 +50,7 @@ information broker), never another role's memory.
 → dotfiles ADR-0033 (pointer-layer content contract), ADR-0036 (MCP knowledge-graph), ADR-0046
 (hosted per-role stores — supersedes ADR-0043's two-tier shared model). Build track: dotfiles#602.
 
-## What earns a shared agent — the structural-edge filter — [Directional]
+## What earns a shared agent — the structural-edge filter — [Decided]
 
 Build a team agent only where it has an edge a private session lacks. A role clears the bar only if
 it passes all three gates: **structural edge** (≥1 of accumulated team memory / structural
@@ -55,7 +65,9 @@ Sharpest case: the **backlog-manager is the cross-stakeholder intake funnel** �
 inbound stream (eng, SRE, product, security, perf, feedback) converges, so it alone can dedupe
 across them and propose one priority. It _proposes_; the human _disposes_.
 
-→ dotfiles#560 (roster + operating model, incubating).
+→ dotfiles ADR-0042 (roster); dotfiles#560 (incubating machinery). Promoted [Directional] →
+[Decided] 2026-08-26: the three-gate filter survived four unmodified applications in the roster
+audits (agents#53).
 
 ## Invocation — invitation is the authorization — [Decided stance / Directional mechanism]
 
@@ -106,6 +118,15 @@ deterministic rule pushed down into tooling is one less thing a probabilistic mo
 Two domains, don't conflate them: **adoption** wins by ergonomics (soft — the plan-review gate is
 discipline, not a wall); **correctness** gets a hard wall (a CI check). Each is right for its kind.
 
+**The enforcement ladder — [Decided].** Rules land on the highest rung worth reaching:
+substrate-native (rulesets, native mechanics, required CI) → third-party tooling (lefthook,
+gitleaks) → own code (`scripts/`) → agent hooks → model judgment in a gate (an agent verdict
+wired to a substrate enforcement point) → prose, last, ideally with a deterministic detection
+backstop. Corollary: the SDLC is invariant when agents join — the process doesn't change, but
+gaps a human covered implicitly must be surfaced and explicitly covered on a rung (or a named
+human gate) before the seat counts as filled. → agents ADR-0003 (the why and the rejected
+alternatives).
+
 → dotfiles ADR-0025 (advisory pipeline: soft plan gate + `pr-code-review`).
 
 ## Provider-agnostic by design — [Directional]
@@ -147,6 +168,17 @@ Constraints carried from external multi-agent practice onto our own tracks:
 - **Orchestration is deterministic — keep it off the LLM.** Sequencing, exit checks, and retry are
   deterministic problems; a model given them drifts and burns tokens. Workflow state lives in GitHub
   labels (`needs-plan-review` → `plan-approved`), not an agent's context.
+- **Review the artifact, not only the plan.** Separate-context review of completed artifacts caught
+  real errors in every roster audit that ran one (agents#54–#57) — the diamond applies to outputs,
+  not just approaches.
+- **Working state is ticket-scoped, public, and dies at completion.** The reviewer's thread, the
+  implementor's PLAN.md, the review dance's PR thread — one pattern, three surfaces. Never private
+  state: reasoning that influences the next round lives where a human can audit it.
+- **Escalate up a ladder, exhausted in order.** Self-resolution → the reviewing agent → the
+  backlog-manager → a human (agents#55). Minimal human escalation is a goal, not an accident.
+- **Check the substrate for the primitive before designing one.** GitHub's native review-request
+  gave the code-reviewer its invitation, re-invitation, verdict vocabulary, and wake state for
+  free — the plan-reviewer must build the same from parts (agents#57 vs agents#64/#65).
 
 ## Decision index
 


### PR DESCRIPTION
Reconciles the operating model with the signed roster charters (the #53 arc). Three changes:

- **Memory-is-the-moat → per-role edges.** The audits dented the universal claim: two of four roles are deliberately store-less (thread = memory, reaffirmed at charter #56/#57) and their edge is independence; the code-reviewer's is the gate. Memory stays the backlog-manager's moat; the section now says so honestly.
- **Core-invariant trajectory note ([Directional]).** Two signed charters (#55/#57) record the decided direction of the merge leg — future auto-merge gated by a blocking reviewer, shipping as a ruleset change + superseding ADRs (#67; an invariant ADR at flip time). The invariant binds unchanged today; the doc just stops pretending no trajectory exists.
- **Four proven orchestration lessons**: review the artifact, not only the plan (4/4 catch record); ticket-scoped public working state (thread / PLAN.md / dance — one pattern); the escalation ladder; substrate-native beats built.

**Filter promotion included** (maintainer-approved): structural-edge filter [Directional] → [Decided], four-application evidence noted in-doc.

**Also added (maintainer-decided post-#71-merge): ADR-0003, the enforcement ladder** — substrate-native → third-party tooling → own code → agent hooks → prose, with the SDLC-invariance corollary (the process doesn't change when agents join; implicitly-human-covered gaps get surfaced and explicitly covered). Operating model cites it from the deterministic-work section; the ADR carries the why and rejected alternatives. Rebased onto post-#71 main.

Executed by the backlog-manager under the explicit maintainer waiver recorded on #70; commit authored as the agent (ADR-0038), PR on the ambient token (agent account is read-only — pre-#540 limit), merge stays yours.

Closes #70


