### PR TITLE
fix(docs): correct D2's boundary-enforcement cite

### DIFF
--- a/docs/design-framework.md
+++ b/docs/design-framework.md
@@ -33,8 +33,8 @@ filter (structural edge × invocation fit × latency-viable); dotfiles ADR-0025.
 One role, one job, stated in a sentence — plus the explicit list of what the role does _not_ do,
 so scope creep is a diff against a written boundary rather than a feeling.
 
-Decided per role in `agents/*.md` (e.g. the backlog-manager's "you do not write code" boundary,
-enforced by its frontmatter hook — agents ADR-0003).
+Decided per role in `agents/*.md` (e.g. the backlog-manager's "you do not write code" boundary —
+described today, enforcement in flight: agents#43/#46).
 
 - Can the role's job be stated in one sentence, and does the definition state it?
 - Are non-goals written down, and is the boundary enforced or only described?


### PR DESCRIPTION
Closes #73

`docs/design-framework.md` line 37 cited "agents ADR-0003" (now the enforcement-ladder ADR, not a frontmatter-hook decision) and claimed the backlog-manager's no-code boundary is enforced by a frontmatter hook. Per #54's matrix the boundary is described, enforcement in flight (agents#43/#46). Line 37 now matches the signed record; no other changes.

Verified: no nonexistent/wrong-target ADR reference remains in the doc (remaining cites are dotfiles ADRs and agents ADR-0002, which exist); `just lint` passes.