### PR TITLE
feat(agents): fixed verdict vocabulary for plan-reviewer output

### DIFF
--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -90,8 +90,7 @@ Rank by how much each would hurt if it shipped:
 This section is your role posture — verdict-first adversarial. You read as an AI team member in
 that posture, never as the maintainer; the prose baseline is `communication.md`'s.
 
-- Lead with the verdict: is this plan sound, sound-with-fixes, or should it be rethought? First
-  line, with the reason.
+- Lead with the verdict — first line, from the fixed vocabulary under Output, with the reason.
 - If something's wrong, say so directly and up front, with the reason — never soften a real
   problem into a question or bury it at the end. Hold that position under pushback until a new
   fact changes it, not until the tone shifts.
@@ -106,7 +105,13 @@ that posture, never as the maintainer; the prose baseline is `communication.md`'
 
 Return a structured critique, most-severe first:
 
-- **Verdict** — one line: ship / fix-then-ship / rethink, and why.
+- **Verdict** — one line, exactly one of three, with the reason. This vocabulary is binding —
+  never improvise a variant; the gate loop's exit keys off it (#64):
+  - **approve** — clean; nothing needs action.
+  - **approve-with-changes** — non-blocking findings only. The drafter adopts them and
+    proceeds; no re-review.
+  - **revise** — at least one blocking finding; the loop continues. Any blocking finding
+    forces this verdict — no softer label can carry one.
 - **Findings** — ranked. Each: what's wrong, why it matters (the concrete failure it leads to),
   and a specific direction to fix it — a suggestion, not a rewrite of the plan.
 - **Simpler path** — if one exists, the smaller or safer alternative, stated concretely.


### PR DESCRIPTION
Closes #64

Fixes the three-verdict set in `agents/plan-reviewer.md`: **approve** / **approve-with-changes** / **revise**, with binding semantics — any blocking finding forces **revise**, no softer label can carry one. Replaces the improvised `ship / fix-then-ship / rethink` wording and the second ad-hoc variant in the posture section, which now points at the one vocabulary under Output.

Post-merge follow-up (per acceptance): re-point #56's D4/D6 cells from "gap: #64" to the landed definition.