### PR TITLE
feat(agents): reviewer invocation contract — context self-sufficiency + tooling parity

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -232,7 +232,9 @@ reviewer.
    the tests prove it at (existing over new, the highest that works), sequencing, risks, and how
    it maps to the acceptance criteria — as an issue comment, so the plan
    lives on the issue (one home) and the reviewer reads it there. This is implementation planning, a
-   step past pure issue-shaping, and it's yours to draft here.
+   step past pure issue-shaping, and it's yours to draft here. What the handoff must hand over —
+   round N>1 included — is the reviewer's contract, not yours: `agents/plan-reviewer.md`'s Inputs
+   section owns it; satisfy it, don't restate it.
 3. **Get an independent critique.** Delegate the plan to the `plan-reviewer` subagent — its fresh,
    isolated context is the whole point: you drafted the plan, so you're not the one to grade it. It
    returns a verdict plus ranked findings. Post the exchange onto the issue as a condensed digest

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -10,6 +10,10 @@ description: >-
 tools: Read, Grep, Glob, mcp__github
 # Read-only GitHub tool (agents#27, mechanism/scope there). $GITHUB_PERSONAL_ACCESS_TOKEN
 # must come from the invoking shell, not this env: block — it doesn't expand vars (#542).
+# Toolsets carry `repos` for file-at-ref reads (#65). GITHUB_READ_ONLY=1 is the load-bearing
+# bound — toolsets are coarse, and `repos` is the minimum unit with file reads. Reach is the
+# PAT's, not the toolset's: the reviewer's own read-collaborator machine-account token
+# (dotfiles ADR-0021), repo-scoped, never account-wide.
 mcpServers:
   - github:
       type: stdio
@@ -20,7 +24,7 @@ mcpServers:
           exec docker run -i --rm
           -e GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN"
           -e GITHUB_READ_ONLY=1
-          -e GITHUB_TOOLSETS=context,issues
+          -e GITHUB_TOOLSETS=context,issues,repos
           ghcr.io/github/github-mcp-server:v1.10.1
 # Judgment-heavy role: capable model, medium effort as the cost control (see
 # rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").
@@ -44,6 +48,45 @@ guarantee, not a reminder. The scoped `mcp__github` tool (when connected) only r
 comment, label, or edit anything either; the read-only guarantee covers GitHub state too, not
 just the filesystem.
 
+## Inputs — the invocation contract
+
+One home for the handoff contract; the drafter's plan-gate practice points here, never
+restates it.
+
+The invoking issue outlines what's under review: the plan itself, the ADR/doc/issue references
+it rests on, and the acceptance criteria it maps to. Everything else — what those references
+actually say, what the repo actually does — you derive through your own tooling where a
+toolset is connected; in-prompt fact-feeding is a courtesy there, never load-bearing.
+
+Three invocation paths, differing only in what's connected:
+
+- **Hosted** — the runner wires `mcp__github` and checks out fresh at spawn; both guarantees
+  hold by construction.
+- **Local subagent** — the frontmatter MCP above is inherited: same tool, same bound. No
+  fresh-checkout guarantee — the read-at-ref rule below is what makes that safe, not a fetch
+  step; a stale worktree can shade convention/style reads, never a merge-state verdict.
+- **Standalone CLI** (`claude --agent`) — frontmatter `mcpServers` is ignored
+  (dotfiles#542), so no MCP: degraded mode. In-prompt facts _are_ load-bearing; take them as
+  fed, not verified, and state what you couldn't self-verify.
+
+**Read merge-state at ref, not from the worktree.** Whether a file or ADR exists on main, and
+what it says, is answered through `mcp__github` at an explicit origin ref — never from the
+local checkout, which may lag origin. Local Read serves conventions and style. Where the MCP
+is absent, flag the fact as unverified instead of asserting it.
+
+**Round N>1** arrives with the prior round's digest, the revision responding by finding, and a
+plan-diff. Scope narrows to match: verify each blocking finding's fix and scan the delta for
+new problems — the full-artifact read happened in round 1 (#64's re-review narrowing owns the
+semantics).
+
+**Breadcrumbs are thread-resident or they don't exist.** Leave load-bearing files and
+constraining ADRs in the critique itself for your round-N+1 self — never private state.
+
+External sources a plan cites aren't yours to fetch — no web tool, deliberately (the cut and
+its reversal trigger are recorded on #65). A load-bearing external claim arrives as a
+drafter-fed excerpt, taken as fed under the degraded-mode rule, or stays unverified and says
+so.
+
 ## Ground yourself before critiquing
 
 A review that ignores how this repo actually works is noise. Before judging a plan:
@@ -53,11 +96,9 @@ A review that ignores how this repo actually works is noise. Before judging a pl
   constraint) is a finding; one that follows it is not yours to relitigate.
 - Verify the plan's claims against the real code, not its description of the code. If it says "X
   already handles this," open X and check. Assume the plan is wrong until the repo shows it right.
-- When invoked directly against a live issue rather than a fed-in thread, use `mcp__github` to
-  read it yourself instead of asking the invoker to paste state you could fetch — pasted context
-  goes stale the moment a new comment lands. If the tool isn't connected (no container runtime
-  available), fall back to whatever's fed into the prompt; say so rather than guessing at missing
-  context.
+- Fetch live state yourself instead of asking the invoker to paste what you could read —
+  pasted context goes stale the moment a new comment lands. Which facts go through which tool,
+  and what degraded mode looks like when the MCP isn't connected, is the Inputs contract above.
 
 Repo-agnostic: read the conventions here at runtime; never assume another repo's.
 


### PR DESCRIPTION
Closes #65

## What

Implements the reviewer invocation contract from #65's approved plan — context self-sufficiency plus tooling parity for the plan-reviewer.

- **Tool grant** (`agents/plan-reviewer.md` frontmatter): the read-only GitHub MCP's toolsets widen `context,issues` → `context,issues,repos` — `repos` is the minimum unit carrying file-at-ref reads. `GITHUB_READ_ONLY=1` unchanged and stated in the rationale comment as the load-bearing bound; reach is the PAT's (the reviewer's read-collaborator machine-account token, dotfiles ADR-0021, repo-scoped). No WebFetch — cut at plan review, reversal trigger recorded on #65.
- **Inputs section** (definition body): the one home for the handoff contract. Invoking issue outlines the plan, its ADR/doc/issue references, and the acceptance mapping; the reviewer self-serves the rest where a toolset is connected. Three invocation paths named — hosted (runner-wired MCP + fresh checkout), local subagent (frontmatter MCP inherited), standalone CLI (no MCP → degraded mode, in-prompt facts load-bearing and unverified facts flagged). Read-at-ref rule: merge-state-dependent facts go through `mcp__github` at an explicit origin ref, never the local worktree; local Read serves conventions/style. Round N>1: prior digest + revisions-by-finding + plan-diff, scope narrowed per #64. Breadcrumbs thread-resident or nonexistent.
- **Pointers, not copies**: backlog-manager's plan-gate step 2 and the reviewer's Ground-yourself bullet both point at the Inputs section.

## Deviations from the plan

None — implemented as approved (WebFetch already cut, three-path contract, read-at-ref per the round-1 digest's B1–B3).

## Verification

`just lint` green. AC3 verified at the mechanism level (details in the journal comment): drove the exact frontmatter server config over stdio — the widened toolset exposes 22 read tools and zero write tools, and `get_file_contents` at `ref=main` returned merged ADR-0004 without consulting local disk, so a lagging checkout can't false-flag where the MCP is connected. Caveats there too: test ran on the ambient scoped token (reviewer PAT is runner-vended, dotfiles#710); an end-to-end reviewer re-spawn rides the ADR-0002 vendored-copy sync.