### PR TITLE
docs: name the role↔repo seam — discover, never encode

### DIFF
--- a/docs/design-framework.md
+++ b/docs/design-framework.md
@@ -245,6 +245,7 @@ provider-neutral home (dotfiles ADR-0039, agents ADR-0002).
 - When was the definition last changed, and was the change driven by observed behavior?
 - Does the definition carry provenance for its load-bearing lines (pointers, verified-at notes)?
 - Is anything in it dead — a rule for a situation that no longer exists?
+- Does the definition carry any fact the repo owns? (operating-model.md "The role↔repo seam")
 
 ### D18. Interfaces and orchestration
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -140,6 +140,30 @@ core; Claude Code is the one concrete binding today.
 
 → dotfiles ADR-0039 (this repo's extraction as a submodule).
 
+## The role↔repo seam — agents discover conventions, never encode them — [Decided]
+
+Sibling to the provider↔content seam above: repos own their conventions — lint, CI,
+commit/branch/PR structure, issue templates, code style — enforced repo-side (rulesets and CI,
+agents ADR-0003 rungs 1–2); agents **discover** them at runtime. A definition may encode the
+_procedure for discovering_ a repo's conventions, never the conventions themselves. The
+one-question test: **would this line change if the repo changed? Then it belongs to the repo.**
+
+The practice already lives at the seam's corners — the implementor's Phase 0 discovery
+(`agents/implementor.md`, `skills/orient`), `implement-issue`'s zero-mechanics-restated step, the
+backlog-manager's learn-this-repo-first preamble and issue-template deference, the rules tree's
+LOCAL-WINS headers. This section is their shared name, not a fifth copy.
+
+Repo-side obligation: LOCAL-WINS only works when there's a local to win — each managed repo owes
+its own workflow doc (`rules/tools/git.md`'s COMPOSE step). A repo without one inherits the
+generic baseline as de-facto policy; that inheritance must be a visible choice, recorded in the
+repo, not silence.
+
+Drift detection: the `audit-rules` skill's repo-fact-in-definition check (prose + deterministic
+detection backstop — ADR-0003 rung 6); the design framework asks the same question per
+definition under D17.
+
+→ agents#84 (naming); agents ADR-0003 (enforcement-side placement).
+
 ## Manageable and measured — [Directional]
 
 A manager manages an agent two ways: (a) **editing its shared, versioned definition** — an agent's

--- a/skills/audit-rules/SKILL.md
+++ b/skills/audit-rules/SKILL.md
@@ -2,12 +2,14 @@
 name: audit-rules
 description: >-
   Audits the global Claude Code agent-config rules tree (~/.claude/rules) for
-  contradictions and topic/length sprawl, and checks AGENTS.md/README.md/docs for content
-  substantially duplicated across them, reporting proposed fixes without editing anything.
-  Use when asked to audit, review, or check the rules tree for contradictions, conflicting
-  directives, files that have grown too long or cover more than one topic, or repo docs
-  that restate the same content in more than one place. Read-only — never invoke this to
-  apply a fix, only to find issues.
+  contradictions and topic/length sprawl, checks AGENTS.md/README.md/docs for content
+  substantially duplicated across them, and checks agent definitions for encoded repo
+  facts a role should discover at runtime, reporting proposed fixes without editing
+  anything. Use when asked to audit, review, or check the rules tree for contradictions,
+  conflicting directives, files that have grown too long or cover more than one topic,
+  repo docs that restate the same content in more than one place, or agent definitions
+  that hardcode a repo's conventions. Read-only — never invoke this to apply a fix, only
+  to find issues.
 argument-hint: "[path]"
 allowed-tools: Read, Glob, Grep
 disallowed-tools: Write, Edit
@@ -18,14 +20,18 @@ disallowed-tools: Write, Edit
 Read-only audit of the global agent-config rules tree for the two maintenance issues the
 removal test cares about: contradictions and sprawl. Also checks this repo's own docs
 (AGENTS.md/README.md/docs) for content replicated across them — a doc↔doc instance of the same
-single-source-of-truth problem, and a named cause of sprawl. Report findings and proposed
+single-source-of-truth problem, and a named cause of sprawl — and agent definitions for
+encoded repo facts (the role↔repo seam's drift detector). Report findings and proposed
 fixes — never edit anything yourself. `disallowed-tools` already blocks Write/Edit
 structurally; treat that as a guarantee, not just a reminder.
 
 ## Scope
 
-Read target: `~/.claude/rules/**/*.md`. Never hardcode a specific repo's path (e.g. a
-dotfiles checkout) — this must work from any repo where the rules are deployed.
+Read target: `~/.claude/rules/**/*.md`, plus the agent definitions where they're found —
+`~/.claude/agents/**/*.md` when deployed, and the current repo's `agents/*.md` when present
+(read each definition once; if both locations resolve to the same content, one read suffices).
+Never hardcode a specific repo's path (e.g. a dotfiles checkout) — this must work from any repo
+where the rules are deployed.
 
 If invoked with a path argument, scope the audit to that file or directory instead of the whole
 tree (useful mid-edit on a single file). Otherwise audit everything.
@@ -178,6 +184,22 @@ Scope stays to the docs an agent relies on for context — AGENTS.md, README.md,
 content by nature, not drift by accident) and don't extend this check to CHANGELOG.md,
 per-tool READMEs, or code comments.
 
+## Repo-fact-in-definition check
+
+The role↔repo seam's drift detector: repos own their conventions, agent definitions encode only
+the procedure for discovering them. The seam and its one-question test live in the agents repo's
+`docs/operating-model.md` ("The role↔repo seam") — apply that test to each load-bearing line of
+every agent definition in scope; don't re-derive it here. Typical shapes that fail it: a concrete
+branch name, a commit-type or label list, a CI or build command, a directory layout, an issue
+template's field list — any value the definition would act on that the repo, not the role, owns.
+
+A repo fact quoted as an illustrative example inside a discovery instruction ("e.g. `main`") is
+fine; a hardcoded value the agent would act on without discovering it is the target. Same
+quiet-on-noise bar as the Cross-doc replication check: when in doubt, don't report it.
+
+Each finding quotes the line, names the repo fact it encodes, and proposes the discovery-form
+rewrite — same format as the Contradictions check, this is not a new report shape.
+
 ## Report
 
 Emit one structured markdown report directly in this response:
@@ -200,6 +222,10 @@ No edits made — this is a proposal only.
 (ranked, or "None found.")
 
 ## Cross-doc replication
+
+(ranked, or "None found.")
+
+## Repo facts in definitions
 
 (ranked, or "None found.")
 


### PR DESCRIPTION
Closes #84

Names the role↔repo seam in the operating model — repos own their conventions, agents discover them at runtime and never encode them — with the one-question test (*would this line change if the repo changed? Then it belongs to the repo*), pointers to the four existing embodiments, and the repo-side LOCAL-WINS obligation (inheriting the generic baseline is a recorded choice, not silence).

- `docs/operating-model.md`: new **[Decided]** section, sibling to the provider-agnostic section. The test's single home.
- `docs/design-framework.md`: one D17 audit question — *does the definition carry any fact the repo owns?* — citing the section.
- `skills/audit-rules/SKILL.md`: repo-fact-in-definition check as the seam's detection backstop (ADR-0003 rung 6): scope extended to agent definitions, check applies the test by pointer, report gains a matching section.

Verification: `just lint` clean; the test sentence greps to exactly one location (acceptance: each artifact cites, none restates, the test appears once).