### PR TITLE
docs: provider-agnostic sequencing — one binding, seam, ledger

### DIFF
--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -129,7 +129,7 @@ alternatives).
 
 → dotfiles ADR-0025 (advisory pipeline: soft plan gate + `pr-code-review`).
 
-## Provider-agnostic by design — [Directional]
+## Provider-agnostic by design — [Directional goal / Decided sequencing]
 
 Definitions, rules, personas, and memory should be portable across providers (Claude, Codex, and the
 rest), never locked to one. Keep the _content_ neutral — personas, process, acceptance, the MCP
@@ -138,7 +138,31 @@ isolate provider coupling to a thin adapter/binding layer. Same "domain before t
 the agent's meaning is the stable core, the provider binding is transport. This repo _is_ the neutral
 core; Claude Code is the one concrete binding today.
 
-→ dotfiles ADR-0039 (this repo's extraction as a submodule).
+**Sequencing — one binding until a second is real (decided 2026-08-26, agents#76).** Build against
+Claude Code alone, record couplings in the ledger below as they surface, extract the binding layer
+only when a second provider actually arrives — the wrong-abstraction guard: an adapter designed
+against one concrete case abstracts the wrong things.
+
+**The seam convention.** In a definition, frontmatter (`tools`, `model`, effort, `mcpServers`,
+`hooks`) is the provider binding; the markdown body is the neutral core — a body never names a
+harness mechanism. Binds every definition at authoring (#66/#67 were the first).
+
+**The ladder is the seam's map.** ADR-0003's rungs 1–3 (substrate-native, third-party tooling, own
+code) are model-independent by construction; rung 4 (agent hooks) and rung 6 (prose) are the
+harness-coupled rungs. Shift-left buys portability, not just drift-immunity.
+
+**Coupling ledger** — grows as couplings surface, never speculatively:
+
+- Coupled to Claude Code: `PreToolUse` and kin (frontmatter `hooks`), skills discovery, frontmatter
+  `mcpServers` quirks (dotfiles#542), `model`/effort fields, output styles, rules-tree loading.
+- Portable by construction: MCP memory (ADR-0046), substrate mechanics (GitHub), rungs 1–3, body
+  prose content.
+
+**A swap is never just config.** Prose rules are calibrated to a model's observed failure modes, so
+swapping providers means rebind _and_ re-tune against measured failure classes — dotfiles#545's
+telemetry is the swap acceptance harness.
+
+→ dotfiles ADR-0039 (this repo's extraction as a submodule); agents#76 (sequencing decision).
 
 ## The role↔repo seam — agents discover conventions, never encode them — [Decided]
 


### PR DESCRIPTION
Closes #76

Amends the operating model's "Provider-agnostic by design" section with build sequencing, per the issue's plan:

- **Sequencing (decided 2026-08-26):** build against one binding (Claude Code), record couplings as found, extract the binding layer only when a second provider is real — the wrong-abstraction guard. Section tag moves [Directional] → [Directional goal / Decided sequencing].
- **Seam convention:** definition frontmatter (tools, model, effort, mcpServers, hooks) = provider binding; markdown body = neutral core, never names a harness mechanism.
- **Ladder tie-in:** ADR-0003 rungs 1–3 model-independent by construction; rungs 4 and 6 harness-coupled — shift-left is portability, not just drift-immunity.
- **Starter coupling ledger:** coupled (hooks, skills discovery, mcpServers quirks per dotfiles#542, model/effort, output styles, rules-tree loading) vs portable by construction (MCP memory per ADR-0046, substrate mechanics, rungs 1–3, body prose).
- **Swap is never just config:** prose rules are calibrated to a model's observed failure modes; a swap = rebind + re-tune, with dotfiles#545's telemetry as the acceptance harness.

Deviation from the issue: #66/#67 closed before this landed ("binds at authoring" moment passed) — the acceptance clause is realized as pointer comments on both closed issues rather than body edits; the doc names them as the first definitions bound. See the journal comment.

Verification: `just lint` green; single commit, Conventional subject.