### PR TITLE
feat(agents): role-scope skill access

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -7,6 +7,11 @@ description: >-
   closing stale items. Use proactively whenever the user describes a feature, bug, idea,
   or work worth tracking.
 tools: Bash, Read, Grep, Glob, Agent(plan-reviewer), mcp__memory
+# No Skill tool, deliberately (#87, wiring decision #44): Skill is all-or-nothing — listing it
+# loads every discovered skill's description into this role's context (implementor-shaped bait).
+# This role's two skills (grilling, groom-backlog) are reached by plain Read of their SKILL.md
+# files, per the body. Standalone `--agent` honors `tools:`, and the skill files read in both
+# standalone and subagent modes (verified empirically, evidence on #87).
 # Guinea-pig wiring for the MCP memory trial (carpet-stain/dotfiles ADR-0036,
 # carpet-stain/dotfiles#527). Inline so the
 # server rides subagent runs with no per-repo .mcp.json. Subagent-only:
@@ -133,7 +138,12 @@ stay yours, not the template's. Absent templates, use the baseline below:
 ## Grill by default
 
 Shaping a non-trivial issue means running the `grilling` skill — collaborative
-requirement-gathering, not filing on assumptions. The skill's own "when to use" list is the one
+requirement-gathering, not filing on assumptions. Read its `SKILL.md` yourself, resolved in
+order: Glob `**/skills/grilling/SKILL.md` from the working directory (roster checkout or
+vendored submodule) — exactly one match wins; zero or several, use
+`~/.claude/skills/grilling/SKILL.md` (the deployed home). Nothing surfaces it to you
+automatically; if neither resolves, say so and grill from this section's rules rather than
+improvising the skill's procedure (#87). The skill's own "when to use" list is the one
 home for its triggers; don't restate it here.
 
 - **Skip only when ALL hold**: one well-understood deliverable, obvious acceptance, zero open
@@ -259,9 +269,10 @@ that first.
 
 ## Groom on a cadence
 
-Run the `groom-backlog` skill for the periodic sweep procedure — one home for the checklist, not
-restated here. This repo's own sweep notes live in the memory graph (the
-`gh-conventions` entity and friends); the skill's last step reads them.
+Run the `groom-backlog` skill (its `SKILL.md` resolved the same way as `grilling`'s) for the
+periodic sweep procedure — one home for the checklist, not restated here. This repo's own
+sweep notes live in the memory graph (the `gh-conventions` entity and friends); the skill's
+last step reads them.
 
 **A stale `blocked` label is a defect to fix on sight, not a preference.** If every reference it
 names has resolved (a native `blocked-by` link closed, or the label's own reason line points at

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -7,6 +7,9 @@ description: >-
   request; round N+1 is a re-request. Not for plans or pre-implementation artifacts (the
   plan-reviewer's lane), and it never writes code — comments and reviews only.
 tools: Read, Grep, Glob, Bash
+# No Skill tool, deliberately (#87): this role consumes no skills, and listing Skill would load
+# every discovered skill's description into its context (other roles' bait). Standalone
+# `--agent` honors `tools:` (verified empirically, #87).
 # Judgment-heavy adversarial role: the blocking verdict is where being wrong is expensive, so it
 # gets the capable model; medium effort is the cost control (see
 # rules/universal/ai-collaboration.md, "Match Model And Effort To Task Risk").

--- a/agents/implementor.md
+++ b/agents/implementor.md
@@ -8,6 +8,11 @@ description: >-
   implement-issue skill remains the wrapper — the modes coexist. Never redesigns the ticket,
   never edits its own rules.
 tools: Read, Edit, Write, Bash, Grep, Glob
+# No Skill tool, deliberately (#87, wiring decision #44): Skill is all-or-nothing — listing it
+# loads every discovered skill's description into this role's context (other roles' bait). The
+# pack's five phase skills are reached by plain Read of the files the body names — zero context
+# tax until read. Standalone `--agent` honors `tools:`, and the pack files read in both
+# standalone and subagent modes (verified empirically, evidence on #87).
 # Execution under an approved plan is the mechanical tier: Sonnet per dotfiles ADR-0025's model
 # tiering (its amendment moved the implementer tier from Haiku to Sonnet); effort medium — the
 # pack carries the judgment (see rules/universal/ai-collaboration.md, "Match Model And Effort
@@ -37,7 +42,12 @@ Harness integration (the pack is portable; these bind it to this workflow):
 - Consult the matching phase skill at each gate: `orient` (gate 1 / Phase 0), `test-strategy`
   (gate 2 / Phase 1, with its domain variants), `test-list` (gate 3 / Phase 2), `tdd-loop`
   (gate 4 / Phase 3), `refactor-review` (gate 5 / Phases 4–5). Gate numbers are the rules
-  list below; skills carry the pack's zero-indexed phase names — same five stops.
+  list below; skills carry the pack's zero-indexed phase names — same five stops. Consult means
+  read the skill's own `SKILL.md` yourself, resolved in order: Glob `**/skills/<name>/SKILL.md`
+  from the working directory (roster checkout or vendored submodule) — exactly one match wins;
+  zero or several, use `~/.claude/skills/<name>/SKILL.md` (the deployed home; outside the
+  working directory the read may need a grant). Nothing surfaces the pack to you automatically;
+  if neither resolves, record the miss in `PLAN.md` and work from the rules below (#87).
 - The pack is tuned from observed failures, not intuition: run it on real tickets, revise where
   the agent blends phases, weakens assertions, or abuses an exception — and tighten an abused
   exception's trigger rather than deleting it. Pack-feedback flags in final reports feed this

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -8,6 +8,9 @@ description: >-
   plan, design, or refactor. Not for reviewing finished code diffs (that's `/code-review`), and
   it never writes code or files — it only critiques.
 tools: Read, Grep, Glob, mcp__github
+# No Skill tool, deliberately (#87): this role consumes no skills, and listing Skill would load
+# every discovered skill's description into its context (other roles' bait). Standalone
+# `--agent` honors `tools:` (verified empirically, #87).
 # Read-only GitHub tool (agents#27, mechanism/scope there). $GITHUB_PERSONAL_ACCESS_TOKEN
 # must come from the invoking shell, not this env: block — it doesn't expand vars (#542).
 # Toolsets carry `repos` for file-at-ref reads (#65). GITHUB_READ_ONLY=1 is the load-bearing

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -153,8 +153,9 @@ harness-coupled rungs. Shift-left buys portability, not just drift-immunity.
 
 **Coupling ledger** — grows as couplings surface, never speculatively:
 
-- Coupled to Claude Code: `PreToolUse` and kin (frontmatter `hooks`), skills discovery, frontmatter
-  `mcpServers` quirks (dotfiles#542), `model`/effort fields, output styles, rules-tree loading.
+- Coupled to Claude Code: `PreToolUse` and kin (frontmatter `hooks`), skills discovery, the
+  deployed skills path (`~/.claude/skills`, agents#87), frontmatter `mcpServers` quirks
+  (dotfiles#542), `model`/effort fields, output styles, rules-tree loading.
 - Portable by construction: MCP memory (ADR-0046), substrate mechanics (GitHub), rungs 1–3, body
   prose content.
 


### PR DESCRIPTION
Closes #87

## What changed

All four role definitions (`agents/*.md`), plus one coupling-ledger line in `docs/operating-model.md`:

- **implementor**: the five phase skills (orient, test-strategy, test-list, tdd-loop, refactor-review) are reached by reading each skill's own `SKILL.md` at its gate, resolved deterministically — Glob `**/skills/<name>/SKILL.md` from the working directory first, deployed `~/.claude/skills/<name>/` as fallback, fail-open into the always-in-context rules with a PLAN.md note on a miss. Frontmatter records why `Skill` stays out of `tools:`.
- **backlog-manager**: same wiring and resolution order for grilling and groom-backlog at their run-sites; same frontmatter record.
- **plan-reviewer, code-reviewer**: consume no skills — the previously accidental `Skill` omission is now recorded as deliberate.
- **operating-model.md**: the deployed skills path joins the coupling ledger (a harness coupling this change surfaces — the ledger's own contract).
- General/maintainer sessions untouched: the full pool stays description-triggered there (implement-issue, audit-rules, compose-agents, audit-memory).

## Why this wiring

Per #44's skills-tier decision, the scoping ships on the agent-frontmatter surface. Of the three candidate wirings, `Skill` in `tools:` is unscoped (whole pool visible — other roles' bait) and `skills:` preload inverts skills' on-demand economics with unverified standalone behavior. Plain Read of the definition-named files is scoped, costs nothing until the gate that reads it, and is verified in both modes. Full rationale in the journal comments.

## Verification

- Empirical probes, both modes (evidence on #87): `tools:` honored standalone and as a subagent — without `Skill`, zero pool descriptions load in either mode; with it, the entire pool. The named `SKILL.md` files read successfully in both modes; a headless outside-cwd read can need a permission grant, which the resolution order accounts for (cwd Glob primary).
- `just lint` clean.

## Review

Both blocking findings from the advisory review addressed in-thread: deterministic path resolution added; Read-wiring verified empirically in both modes.