### PR TITLE
feat(agents): deny implementor issue-filing, add Follow-ups

### DIFF
--- a/agents/backlog-manager.md
+++ b/agents/backlog-manager.md
@@ -198,6 +198,11 @@ An issue moves through stages; keep each one legible.
   filters, and why `is:blocked` isn't a trustworthy readiness signal on its own.
 - **Link work to issues**: reference the issue from its PR with `Closes #NNN` so the merge closes
   it, and cross-link blockers and duplicates. An issue a PR will close shouldn't be closed by hand.
+- **Sweep Follow-ups blocks.** When an implementor's PR closes its ticket, read the closing
+  comment for a `Follow-ups:` block — the implementor's only sanctioned exit for new work
+  surfaced mid-implementation. File each item as its own shaped, labeled, prioritized issue,
+  cross-linked back to the ticket it came from. Nothing else authorizes the implementor to hand
+  you new scope.
 - **Handle staleness deliberately**: an issue waiting on the reporter gets a `needs-info` nudge,
   then closes after a reasonable wait with a note that it can reopen. Don't let dead issues linger,
   and never silently delete — close with a reason.

--- a/agents/implementor.md
+++ b/agents/implementor.md
@@ -92,6 +92,11 @@ bend only through the exception protocol below.
 - No scope creep in either direction: no unrequested changes (drive-by refactors of
   unrelated code, dependency bumps, formatting sweeps outside touched files), and no
   criterion satisfied only "technically" while violating its evident intent.
+- **NEVER** file, label, or triage anything beyond this ticket's own issue and PR. A
+  follow-up discovered mid-implementation is not yours to open — record it in a
+  `Follow-ups:` block in your closing comment on the ticket (one bullet per item: what,
+  why, suggested cross-links) and stop there. That block is the only sanctioned exit for
+  new work; the backlog-manager sweeps it and files properly.
 - UI/UX testing is out of scope. Do not write browser or visual tests.
 
 ### Phase gates (in order, no skipping)


### PR DESCRIPTION
## Summary

Closes #104.

The first live implementor run (#96) filed and triaged a follow-up issue (#103) itself, riding
the ambient token so it read as maintainer-authored — the backlog-manager is the one door new
work is supposed to enter through, but nothing said so.

- `agents/implementor.md`: new NEVER invariant under Scope — the implementor files and labels
  nothing beyond its own ticket/PR. A follow-up surfaces as a `Follow-ups:` block in its closing
  comment on the ticket instead (one bullet per item: what, why, cross-links) — the only
  sanctioned exit for new work.
- `agents/backlog-manager.md`: the receiving side, under Ticket lifecycle — sweep that block off
  a closing comment and file each item properly.

## Scope note

The issue's own comment thread narrowed scope while this was in flight: the credential-enforcing
rung (making this true by construction, e.g. an issues-read-only token) now belongs to #367 in
`infra`, tracked separately. This PR is the conduct layer only — the persona-doc invariant plus
the handoff contract, backstop and detection, not mechanical enforcement. #103 already carries a
provenance comment marking it the pre-boundary artifact, so nothing here touches it.

## Verification

Docs-only change to two persona markdown files — no application code or tests apply. Ran this
repo's own pre-commit/pre-push lint suite (prettier, markdownlint, editorconfig-checker,
gitleaks, the shared-conduct equality check) — all clean.