### PR TITLE
feat(agents): implementor discovers credentials before first gh call

### DIFF
--- a/agents/implementor.md
+++ b/agents/implementor.md
@@ -141,6 +141,10 @@ implementation code before Phase 4, no "while I'm here" edits during Phase 5.
 
 ### Version control invariants
 
+- **NEVER** assume the ambient token (`gh auth token`) is your own credential for a `gh`
+  call. Before the first one, read the target repo's AGENTS.md (or equivalent) for the
+  credential path that operation rides. If it names none, STOP and report — that is an
+  escalation, not a guess.
 - One commit per green cycle, containing the test and its implementation
   together. Message references the ticket ID and the test-list item.
 - Never commit on red. Never amend or squash away a red-to-green step.


### PR DESCRIPTION
## Summary

Second live implementor run (dotfiles PR#735) burned minutes on credential
choice: it tested `gh` on the ambient token — the repo's vended App token,
authenticated as `infra-governance[bot]` without the agent knowing it — and
found `agent-gh` only after the maintainer asked. Root cause: not a missing
read-the-docs step (dotfiles' AGENTS.md already documents the routine
model) but that the persona never checked it before the first `gh` call.

`implementor.md` gains a version-control invariant: never assume the
ambient token is your own credential; read the target repo's AGENTS.md for
the credential path before the first `gh` call; a repo naming none is an
escalation, not a guess.

## Verification

- `lefthook run pre-commit` (md-format, markdownlint, gitleaks,
  editorconfig-checker, shared-conduct-sync) — all green on commit.
- `scripts/check-token-budget.sh` — unaffected (`agents/` isn't in the
  always-loaded budget).

## Doc-ownership checklist

- [x] Behavior changed → `agents/implementor.md` is the doc that owns it,
      updated in this PR.
- [ ] ~~Docs point at enforcing config~~ — this is conduct prose, no config
      to point at.
- [ ] ~~ADR~~ — persona conduct-line addition, not an architectural decision.
- [ ] ~~Reverses a recorded decision~~ — n/a.

Closes #105
