### PR TITLE
chore(sync): onboard onto the pst-sync channel

### DIFF
--- a/.github/workflows/pst-sync.yml
+++ b/.github/workflows/pst-sync.yml
@@ -1,0 +1,21 @@
+name: Sync from project-starter-template
+
+# Thin caller — the body lives in the template source repo's
+# reusable-sync.yml — pinned to its moving major tag (its ADR-0004/#110).
+
+# workflow_dispatch alongside schedule: #147's manual on-demand trigger, same
+# idiom as e2e-live.yml (no issue event here, so no blocked-reconcile mirror).
+on:
+  schedule:
+    - cron: "37 14 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  pst-sync:
+    uses: carpet-stain/project-starter-template/.github/workflows/reusable-sync.yml@v1
+    secrets: inherit

--- a/.pst-sync.yml
+++ b/.pst-sync.yml
@@ -1,0 +1,49 @@
+# PST's sync-channel ownership manifest (project-starter-template#147). PST
+# authors this list; a release adds/removes entries, never a hand-edit here
+# except to flip `owned: true` on an entry (see reusable-sync.yml).
+#
+# Language-overlay files (justfile.lang, lefthook-lang.yml) aren't listed
+# here — lefthook-lang.yml is rung 3 by design (ADR-0006), and justfile.lang
+# has no append mechanism yet from the python/typescript templates
+# (project-starter-template#148 follow-up).
+#
+# `anchor` tracks the PST release this entry's content actually ships in —
+# bump every entry together right before cutting that release, not before.
+files:
+  - path: lefthook.yml
+    source: git-flow/template/lefthook.yml
+    anchor: v1.2.0
+  - path: lefthook-base.yml
+    source: git-flow/template/lefthook-base.yml
+    anchor: v1.2.0
+  - path: justfile
+    source: git-flow/template/justfile
+    anchor: v1.2.0
+  - path: justfile.base
+    source: git-flow/template/justfile.base
+    anchor: v1.2.0
+  - path: scripts/new-adr.sh
+    source: git-flow/template/scripts/new-adr.sh
+    anchor: v1.2.0
+  - path: scripts/check-comment-concision.sh
+    source: git-flow/template/scripts/check-comment-concision.sh
+    anchor: v1.2.0
+  - path: scripts/check-envrc-local-example.sh
+    source: git-flow/template/scripts/check-envrc-local-example.sh
+    anchor: v1.2.0
+  - path: .editorconfig
+    source: git-flow/template/.editorconfig
+    anchor: v1.2.0
+  - path: .gitleaks.toml
+    source: git-flow/template/.gitleaks.toml
+    anchor: v1.2.0
+  - path: .markdownlint-cli2.yaml
+    source: git-flow/template/.markdownlint-cli2.yaml
+    anchor: v1.2.0
+    owned: true
+  - path: .yamlfmt
+    source: git-flow/template/.yamlfmt
+    anchor: v1.2.0
+  - path: .prettierrc.json
+    source: git-flow/template/.prettierrc.json
+    anchor: v1.2.0

--- a/justfile.base
+++ b/justfile.base
@@ -19,3 +19,14 @@ adr *args:
 # excludes (CHANGELOG is git-cliff-generated, agent-memory is heredoc notes).
 format:
     git ls-files -z '*.md' ':!:CHANGELOG.md' ':!:.claude/agent-memory/**' | xargs -0 prettier --write
+
+# Wraps the PATH-deployed record-token-cost (dotfiles owns the implementation,
+# git-flow/README.md has the pointer); skips rather than fails if it's absent.
+token-cost issue:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v record-token-cost >/dev/null 2>&1; then
+      echo "token-cost: record-token-cost not on PATH — skipping (see git-flow/README.md)."
+      exit 0
+    fi
+    record-token-cost {{ issue }}

--- a/lefthook-base.yml
+++ b/lefthook-base.yml
@@ -1,67 +1,12 @@
-# Base lefthook jobs — owned by the git-flow template; a language overlay
-# never edits this file (its jobs live in lefthook-lang.yml). The `base` tag
-# is what lint.yml's CI job selects; keep it on every job here.
+# Rung-2 jobs (ADR-0006) — script-backed: each `run:` here invokes a
+# consumer-local scripts/*.sh, so it can't ride lefthook-remote.yml's `@v1`
+# `remotes:` fetch (#146 confirmed live: the script never travels with a
+# remote config, `exit 127`). This file and the scripts it calls sync
+# together via the pst-sync channel instead. Owned by the git-flow template;
+# a language overlay never edits this file. The `base` tag is what lint.yml's
+# CI job selects; keep it on every job here.
 pre-commit:
   jobs:
-    - name: actionlint
-      tags: [base]
-      glob:
-        - ".github/workflows/*.yml"
-        - ".github/workflows/*.yaml"
-      run: actionlint {staged_files}
-
-    - name: md-format
-      tags: [base]
-      glob:
-        - "*.md"
-        - "**/*.md"
-      exclude:
-        - "CHANGELOG.md"
-        - ".claude/agent-memory/**"
-      run: prettier --check {staged_files}
-
-    - name: markdownlint
-      tags: [base]
-      glob:
-        - "*.md"
-        - "**/*.md"
-      exclude:
-        - "CHANGELOG.md"
-        - ".claude/agent-memory/**"
-      run: markdownlint-cli2 {staged_files}
-
-    - name: yaml-format
-      tags: [base]
-      glob:
-        - ".github/dependabot.yml"
-        - ".markdownlint-cli2.yaml"
-        - "lefthook.yml"
-        - "lefthook-base.yml"
-        - "lefthook-lang.yml"
-      run: yamlfmt -lint {staged_files}
-
-    - name: gitleaks
-      tags: [base]
-      # No glob/{staged_files} — content-based scan must cover
-      # .claude/agent-memory/**; never add the markdown exclude list here. Lineage: dotfiles#390.
-      run: gitleaks dir . --no-banner --redact
-
-    - name: shfmt
-      tags: [base]
-      glob:
-        - "scripts/*.sh"
-      run: shfmt -i 2 -ci -d {staged_files}
-
-    - name: shellcheck
-      tags: [base]
-      # No zsh exclude (dotfiles has one for false positives) — this repo ships no zsh.
-      # .envrc/.envrc.local.example carry `# shellcheck shell=bash` since they lack a shebang.
-      glob:
-        - "scripts/*.sh"
-        - ".envrc"
-        - ".envrc.local.example"
-      run: shellcheck {staged_files}
-
     - name: comment-concision
       tags: [base]
       glob:
@@ -71,28 +16,8 @@ pre-commit:
         - "lefthook.yml"
         - "lefthook-base.yml"
         - "lefthook-lang.yml"
+        - "lefthook-remote.yml"
       run: scripts/check-comment-concision.sh {staged_files}
-
-    - name: justfile-format
-      tags: [base]
-      glob:
-        - "justfile"
-        - "justfile.base"
-      # --justfile takes exactly one path; this repo has two real justfiles, so
-      # xargs -n1 runs the check per file instead of passing both at once.
-      run: echo {staged_files} | xargs -n1 just --fmt --check --justfile
-
-    - name: editorconfig-checker
-      tags: [base]
-      glob:
-        - "*"
-        - "**/*"
-      exclude:
-        - "CHANGELOG.md"
-        - ".claude/agent-memory/**"
-      # --disable-indentation: indentation stays each per-language formatter's
-      # job (shfmt/prettier/yamlfmt) — this checker is only the catch-all for the rest.
-      run: editorconfig-checker --disable-indentation {staged_files}
 
     - name: envrc-local-example-sync
       tags: [base]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,19 @@
 # Composition root — base-owned, never edited by an overlay (ADR-0020 in the
-# template's source repo). Base jobs live in lefthook-base.yml (tagged
-# `base`); lefthook-lang.yml ships here as an empty stub a language overlay
-# overwrites with its jobs (tagged `lang`). Locally every layer's jobs run on
+# template's source repo). Base jobs split across two rungs (ADR-0006):
+# self-contained jobs (tagged `base`) live upstream in PST's
+# lefthook-remote.yml, fetched live via `remotes:` pinned to `@v1`; the
+# handful of script-backed base jobs that can't travel that way (also tagged
+# `base`) live in the local lefthook-base.yml instead, synced via pst-sync.
+# lefthook-lang.yml ships here as an empty stub a language overlay overwrites
+# with its jobs (tagged `lang`). Locally every layer's jobs run on
 # commit/push; each CI workflow runs only its own tag slice. Install with
 # `lefthook install`.
+remotes:
+  - git_url: https://github.com/carpet-stain/project-starter-template
+    ref: v1
+    configs:
+      - git-flow/template/lefthook-remote.yml
+
 extends:
   - lefthook-base.yml
   - lefthook-lang.yml

--- a/scripts/new-adr.sh
+++ b/scripts/new-adr.sh
@@ -22,6 +22,17 @@ if [[ ! -f "$TEMPLATE" ]]; then
   exit 1
 fi
 
+# Printed, not gated — the call stays human. Keep in sync with
+# docs/adr/README.md § When to write one.
+cat >&2 <<'CHECKLIST'
+Before filling this in, check it clears the bar:
+  - Architecturally significant, cross-cutting, or expensive to reverse?
+  - Not already captured in a plan-approved issue this would just restate?
+  - Reversing it later costs more than a follow-up PR?
+If none apply: a PR description or a code comment is the right home, not an ADR.
+
+CHECKLIST
+
 # Highest existing NNNN prefix, or 0 so the first real ADR after the seed is
 # numbered one past it. 10# forces base-10 so a leading zero isn't read as octal.
 last=$(find "$ADR_DIR" -maxdepth 1 -name '[0-9][0-9][0-9][0-9]-*.md' -exec basename {} \; |


### PR DESCRIPTION
No-Issue: part of carpet-stain/project-starter-template#149's fleet retrofit,
which spans five PRs across five repos -- #149 closes once all five land
(project-starter-template#161 merged; agent-memory-server#55, agents#121,
golden-ratio-dual-gate#15, infra#371), no single PR closes it alone.

## Summary

Onboards this repo onto PST's rung-2 sync channel (ADR-0006). Plants `.pst-sync.yml` + `.github/workflows/pst-sync.yml` via `retrofit-governance.sh --channel-only` (clean merge, no conflicts), then reconciles the manifest's 12 candidate entries against this repo's actual files.

**Manifest outcome:**

| Entry | Outcome |
| --- | --- |
| `lefthook.yml` | reconciled — this repo predated pst#148's rung ladder dissolution; now wires the `remotes:` block |
| `lefthook-base.yml` | reconciled — shrinks to the 2 script-backed jobs per the same dissolution |
| `justfile.base` | reconciled — was missing the `token-cost` recipe (stale drift) |
| `scripts/new-adr.sh` | reconciled — was missing the pre-flight checklist block (stale drift) |
| `.markdownlint-cli2.yaml` | **`owned: true`** — repo-specific `MD028`/`MD033` overrides, each with an inline comment explaining why (`rules/*.md`'s meta-header and `<placeholder>` conventions) |
| `justfile`, `scripts/check-comment-concision.sh`, `scripts/check-envrc-local-example.sh`, `.editorconfig`, `.gitleaks.toml`, `.yamlfmt`, `.prettierrc.json` | already byte-identical to PST's template — no change, no `owned` flag |

Not touched: `lefthook-lang.yml` (rung 3 by design, not a manifest candidate) and `scripts/pr-review/`/`pr-code-review.yml` (separate carve-out, out of scope).

## Known gap — flagging before merge, not after

PST's `git_url`/`ref: v1` remote (the `remotes:` block now in `lefthook.yml`) points at PST's moving `v1` tag, which is currently `v1.1.0` and predates pst#148's lefthook dissolution — verified via `git ls-remote --tags`. `lefthook-remote.yml` (carrying actionlint, md-format, markdownlint, yaml-format, gitleaks, shfmt, shellcheck, justfile-format, editorconfig-checker) doesn't exist at that tag yet. Confirmed live: `just lint --tag base` merges the remote config with no error, but those 9 jobs simply never register — only `comment-concision`, `envrc-local-example-sync`, and this repo's own `lefthook-lang.yml` jobs (`token-budget`, `shared-conduct-sync`) run. `.github/workflows/lint.yml` runs the identical `just lint --tag base --no-tty` in CI, so CI has the same silent gap: it installs the 9 CLI tools but never invokes them.

This is the correct target state (and the manifest's own `anchor: v1.2.0` on these entries already anticipates the release that fixes it), but until PST tags `v1.2.0`, this repo's CI silently skips those 9 checks instead of failing loud. Journaled as a PR comment when found; repeating here so it's visible at merge time.

## Verification

- `retrofit-governance.sh --channel-only .` merged clean, no conflicts.
- Diffed all 12 candidates against `git-flow/template/<path>` before touching anything.
- `just lint` (full, unscoped) passes locally, including the reconciled `lefthook-base.yml` composition — `token-budget` and `shared-conduct-sync` (this repo's `lefthook-lang.yml` customizations, agents#34) still run correctly through the new base/lang split.
- `just lint --tag base` (CI's scope) passes but with the known gap above.

Part of carpet-stain/project-starter-template#149
